### PR TITLE
Add golden pkg

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,3 +6,7 @@
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.1.4"
+
+[[constraint]]
+  name = "github.com/pmezard/go-difflib"
+  version = "1.0.0"

--- a/golden/example_test.go
+++ b/golden/example_test.go
@@ -1,0 +1,11 @@
+package golden
+
+var t = &FakeT{}
+
+func ExampleAssert() {
+	Assert(t, "foo", "foo-content.golden")
+}
+
+func ExampleAssertBytes() {
+	AssertBytes(t, []byte("foo"), "foo-content.golden")
+}

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -1,0 +1,45 @@
+// Package golden provides function and helpers to use golden file for
+// testing purpose.
+package golden
+
+import (
+	"flag"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testingT interface {
+	Fatalf(string, ...interface{})
+	Fatal(...interface{})
+	Errorf(string, ...interface{})
+}
+
+var update = flag.Bool("test.update", false, "update golden file")
+
+// Get returns the golden file content. If the `test.update` is specified, it updates the
+// file with the current output and returns it.
+func Get(t testingT, actual []byte, filename string) []byte {
+	golden := filepath.Join("testdata", filename)
+	if *update {
+		if err := ioutil.WriteFile(golden, actual, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	expected, err := ioutil.ReadFile(golden)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return expected
+}
+
+// Assert asserts that the actual content and the golden file are equal.
+//
+//    golden.Assert(t, []byte("foo"), "testdata/foo-content")
+//
+// Returns whether the assertion was successful (true) or not (false)
+func Assert(t testingT, actual []byte, filename string) bool {
+	expected := Get(t, actual, filename)
+	return assert.Equal(t, expected, actual)
+}

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -1,45 +1,71 @@
-// Package golden provides function and helpers to use golden file for
-// testing purpose.
+/*Package golden provides tools for comparing large mutli-line strings.
+
+Golden files are files in the ./testdata/ subdirectory of the package under test.
+*/
 package golden
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/pmezard/go-difflib/difflib"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-type testingT interface {
-	Fatalf(string, ...interface{})
-	Fatal(...interface{})
-	Errorf(string, ...interface{})
-}
+var flagUpdate = flag.Bool("test.update-golden", false, "update golden file")
 
-var update = flag.Bool("test.update", false, "update golden file")
-
-// Get returns the golden file content. If the `test.update` is specified, it updates the
-// file with the current output and returns it.
-func Get(t testingT, actual []byte, filename string) []byte {
-	golden := filepath.Join("testdata", filename)
-	if *update {
-		if err := ioutil.WriteFile(golden, actual, 0644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	expected, err := ioutil.ReadFile(golden)
-	if err != nil {
-		t.Fatal(err)
-	}
+// Get returns the golden file content
+func Get(t require.TestingT, filename string) []byte {
+	expected, err := ioutil.ReadFile(Path(filename))
+	require.NoError(t, err)
 	return expected
 }
 
-// Assert asserts that the actual content and the golden file are equal.
-//
-//    golden.Assert(t, []byte("foo"), "testdata/foo-content")
-//
+// Path returns the full path to a golden file
+func Path(filename string) string {
+	return filepath.Join("testdata", filename)
+}
+
+func update(t require.TestingT, filename string, actual []byte) {
+	if *flagUpdate {
+		err := ioutil.WriteFile(Path(filename), actual, 0644)
+		require.NoError(t, err)
+	}
+}
+
+// Assert compares the actual content to the expected content in the golden file.
+// If `--update-golden` is set then the actual content is written to the golden
+// file.
 // Returns whether the assertion was successful (true) or not (false)
-func Assert(t testingT, actual []byte, filename string) bool {
-	expected := Get(t, actual, filename)
-	return assert.Equal(t, expected, actual)
+func Assert(t require.TestingT, actual string, filename string, msgAndArgs ...interface{}) bool {
+	expected := Get(t, filename)
+	update(t, filename, []byte(actual))
+
+	if assert.ObjectsAreEqual(expected, []byte(actual)) {
+		return true
+	}
+
+	diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(expected)),
+		B:        difflib.SplitLines(actual),
+		FromFile: "Expected",
+		ToFile:   "Actual",
+		Context:  3,
+	})
+	require.NoError(t, err, msgAndArgs...)
+	return assert.Fail(t, fmt.Sprintf("Not Equal: \n%s", diff), msgAndArgs...)
+}
+
+// AssertBytes compares the actual result to the expected result in the golden
+// file. If `--update-golden` is set then the actual content is written to the
+// golden file.
+// Returns whether the assertion was successful (true) or not (false)
+// nolint: lll
+func AssertBytes(t require.TestingT, actual []byte, filename string, msgAndArgs ...interface{}) bool {
+	expected := Get(t, filename)
+	update(t, filename, actual)
+	return assert.Equal(t, expected, actual, msgAndArgs...)
 }

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -1,0 +1,82 @@
+package golden_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/golden"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"path/filepath"
+)
+
+type FakeT struct {
+	Failed bool
+}
+
+func (t *FakeT) Fatal(a ...interface{}) {
+	t.Failed = true
+}
+
+func (t *FakeT) Fatalf(string, ...interface{}) {
+	t.Failed = true
+}
+
+func (t *FakeT) Errorf(format string, args ...interface{}) {
+	_, _ = format, args
+}
+
+func TestGoldenGetInvalidFile(t *testing.T) {
+	fakeT := new(FakeT)
+
+	golden.Get(fakeT, []byte("foo"), "/invalid/path")
+	require.True(t, fakeT.Failed)
+}
+
+func TestGoldenGet(t *testing.T) {
+	expected := "content"
+
+	filename, clean := setupGoldenFile(t, expected)
+	defer clean()
+
+	fakeT := new(FakeT)
+
+	actual := golden.Get(fakeT, []byte("foo"), filename)
+	assert.False(t, fakeT.Failed)
+	assert.Equal(t, actual, []byte(expected))
+}
+
+func TestGoldenAssertInvalidContent(t *testing.T) {
+	filename, clean := setupGoldenFile(t, "content")
+	defer clean()
+
+	fakeT := new(FakeT)
+
+	success := golden.Assert(fakeT, []byte("foo"), filename)
+	assert.False(t, fakeT.Failed)
+	assert.False(t, success)
+}
+
+func TestGoldenAssert(t *testing.T) {
+	filename, clean := setupGoldenFile(t, "foo")
+	defer clean()
+
+	fakeT := new(FakeT)
+
+	success := golden.Assert(fakeT, []byte("foo"), filename)
+	assert.False(t, fakeT.Failed)
+	assert.True(t, success)
+}
+
+func setupGoldenFile(t *testing.T, content string) (string, func()) {
+	f, err := ioutil.TempFile("testdata", "")
+	require.NoError(t, err, "fail to setup test golden file")
+	err = ioutil.WriteFile(f.Name(), []byte(content), 0660)
+	require.NoError(t, err, "fail to write test golden file with %q", content)
+	_, name := filepath.Split(f.Name())
+	t.Log(f.Name(), name)
+	return name, func() {
+		require.NoError(t, os.Remove(f.Name()))
+	}
+}


### PR DESCRIPTION
@vdemeester I made a few changes in a second commit, let me know what you think.

I'm thinking `golden.Get()` could maybe be used with `fs.NewFile(..., WithBytes())` for creating test files.

I changed `Assert` to use `difflib` which is already a dependency of `testify` so it shouldn't change dependencies much, but gives us much better errors for multi-line strings.