### PR TITLE
Add skip package

### DIFF
--- a/skip/example_test.go
+++ b/skip/example_test.go
@@ -1,0 +1,32 @@
+package skip
+
+var t = &fakeSkipT{}
+var apiVersion = ""
+
+type env struct{}
+
+func (e env) hasFeature(_ string) bool { return false }
+
+var testEnv = env{}
+
+func MissingFeature() bool { return false }
+
+func ExampleIf() {
+	//   --- SKIP: TestName (0.00s)
+	//           skip.go:19: MissingFeature
+	If(t, MissingFeature)
+
+	//   --- SKIP: TestName (0.00s)
+	//           skip.go:19: MissingFeature: coming soon
+	If(t, MissingFeature, "coming soon")
+}
+
+func ExampleIfCondition() {
+	//   --- SKIP: TestName (0.00s)
+	//           skip.go:19: apiVersion < version("v1.24")
+	IfCondition(t, apiVersion < version("v1.24"))
+
+	//   --- SKIP: TestName (0.00s)
+	//           skip.go:19: !textenv.hasFeature("build"): coming soon
+	IfCondition(t, !testEnv.hasFeature("build"), "coming soon")
+}

--- a/skip/skip.go
+++ b/skip/skip.go
@@ -1,0 +1,124 @@
+/*Package skip provides functions for skipping based on a condition.
+ */
+package skip
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"path"
+	"reflect"
+	"runtime"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type skipT interface {
+	Skip(args ...interface{})
+	Log(args ...interface{})
+}
+
+// If skips the test if the check function returns true. The skip message will
+// contain the name of the check function. Extra message text can be passed as a
+// format string with args
+func If(t skipT, check func() bool, msgAndArgs ...interface{}) {
+	if check() {
+		t.Skip(formatWithCustomMessage(
+			getFunctionName(check),
+			formatMessage(msgAndArgs...)))
+	}
+}
+
+func getFunctionName(function func() bool) string {
+	funcPath := runtime.FuncForPC(reflect.ValueOf(function).Pointer()).Name()
+	return strings.SplitN(path.Base(funcPath), ".", 2)[1]
+}
+
+// IfCondition skips the test if the condition is true. The skip message will
+// contain the source of the expression passed as the condition. Extra message
+// text can be passed as a format string with args.
+func IfCondition(t skipT, condition bool, msgAndArgs ...interface{}) {
+	if !condition {
+		return
+	}
+	source, err := getConditionSource()
+	if err != nil {
+		t.Log(err.Error())
+		t.Skip(formatMessage(msgAndArgs...))
+	}
+	t.Skip(formatWithCustomMessage(source, formatMessage(msgAndArgs...)))
+}
+
+func getConditionSource() (string, error) {
+	lines, err := getSourceLine(3)
+	if err != nil {
+		return "", err
+	}
+
+	for i := range lines {
+		source := strings.Join(lines[len(lines)-i-1:], "\n")
+		node, err := parser.ParseExpr(source)
+		if err == nil {
+			return getConditionArgFromAST(node)
+		}
+	}
+	return "", errors.Wrapf(err, "failed to parse source")
+}
+
+func getSourceLine(stackIndex int) ([]string, error) {
+	_, filename, line, ok := runtime.Caller(stackIndex)
+	if !ok {
+		return nil, errors.New("failed to get caller info")
+	}
+
+	raw, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read source file: %s", filename)
+	}
+
+	lines := strings.Split(string(raw), "\n")
+	if len(lines) < line {
+		return nil, errors.Errorf("file %s does not have line %d", filename, line)
+	}
+	firstLine := line - 10
+	if firstLine < 0 {
+		firstLine = 0
+	}
+	return lines[firstLine:line], nil
+}
+
+func getConditionArgFromAST(node ast.Expr) (string, error) {
+	switch expr := node.(type) {
+	case *ast.CallExpr:
+		buf := new(bytes.Buffer)
+		err := format.Node(buf, token.NewFileSet(), expr.Args[1])
+		return buf.String(), err
+	}
+	return "", errors.New("unexpected ast")
+}
+
+func formatMessage(msgAndArgs ...interface{}) string {
+	switch len(msgAndArgs) {
+	case 0:
+		return ""
+	case 1:
+		return msgAndArgs[0].(string)
+	default:
+		return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
+	}
+}
+
+func formatWithCustomMessage(source, custom string) string {
+	switch {
+	case custom == "":
+		return source
+	case source == "":
+		return custom
+	}
+	return fmt.Sprintf("%s: %s", source, custom)
+}

--- a/skip/skip_test.go
+++ b/skip/skip_test.go
@@ -1,0 +1,97 @@
+package skip
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeSkipT struct {
+	reason string
+	logs   []string
+}
+
+func (f *fakeSkipT) Skip(args ...interface{}) {
+	buf := new(bytes.Buffer)
+	for _, arg := range args {
+		buf.WriteString(fmt.Sprintf("%s", arg))
+	}
+	f.reason = buf.String()
+}
+
+func (f *fakeSkipT) Log(args ...interface{}) {
+	f.logs = append(f.logs, fmt.Sprintf("%s", args[0]))
+}
+
+func version(v string) string {
+	return v
+}
+
+func TestIfCondition(t *testing.T) {
+	skipT := &fakeSkipT{}
+	apiVersion := "v1.4"
+	IfCondition(skipT, apiVersion < version("v1.6"))
+
+	assert.Equal(t, `apiVersion < version("v1.6")`, skipT.reason)
+	assert.Len(t, skipT.logs, 0)
+}
+
+func TestIfConditionWithMessage(t *testing.T) {
+	skipT := &fakeSkipT{}
+	apiVersion := "v1.4"
+	IfCondition(skipT, apiVersion < "v1.6", "see notes")
+
+	assert.Equal(t, `apiVersion < "v1.6": see notes`, skipT.reason)
+	assert.Len(t, skipT.logs, 0)
+}
+
+func TestIfConditionMultiline(t *testing.T) {
+	skipT := &fakeSkipT{}
+	apiVersion := "v1.4"
+	IfCondition(
+		skipT,
+		apiVersion < "v1.6")
+
+	assert.Equal(t, `apiVersion < "v1.6"`, skipT.reason)
+	assert.Len(t, skipT.logs, 0)
+}
+
+func TestIfConditionMultilineWithMessage(t *testing.T) {
+	skipT := &fakeSkipT{}
+	apiVersion := "v1.4"
+	IfCondition(
+		skipT,
+		apiVersion < "v1.6",
+		"see notes")
+
+	assert.Equal(t, `apiVersion < "v1.6": see notes`, skipT.reason)
+	assert.Len(t, skipT.logs, 0)
+}
+
+func TestIfConditionNoSkip(t *testing.T) {
+	skipT := &fakeSkipT{}
+	IfCondition(skipT, false)
+
+	assert.Equal(t, "", skipT.reason)
+	assert.Len(t, skipT.logs, 0)
+}
+
+func SkipBecauseISaidSo() bool {
+	return true
+}
+
+func TestIf(t *testing.T) {
+	skipT := &fakeSkipT{}
+	If(skipT, SkipBecauseISaidSo)
+
+	assert.Equal(t, "SkipBecauseISaidSo", skipT.reason)
+}
+
+func TestIfWithMessage(t *testing.T) {
+	skipT := &fakeSkipT{}
+	If(skipT, SkipBecauseISaidSo, "see notes")
+
+	assert.Equal(t, "SkipBecauseISaidSo: see notes", skipT.reason)
+}


### PR DESCRIPTION
`skip` covers the same use case as `requirements`, but checks the inverse condition. `requirements` can still be handled by negating the condition.

`IfCondition()` will print the source of the condition (see examples)