### PR TITLE
Move examples test file in special `_test` package

### DIFF
--- a/fs/example_test.go
+++ b/fs/example_test.go
@@ -1,10 +1,10 @@
-package fs
+package fs_test
 
 import (
 	"io/ioutil"
-
 	"os"
 
+	"github.com/gotestyourself/gotestyourself/fs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +18,7 @@ var t = fakeTesting{}
 
 // Create a temporary directory which contains a single file
 func ExampleNewDir() {
-	dir := NewDir(t, "test-name", WithFile("file1", "content\n"))
+	dir := fs.NewDir(t, "test-name", fs.WithFile("file1", "content\n"))
 	defer dir.Remove()
 
 	files, err := ioutil.ReadDir(dir.Path())
@@ -28,7 +28,7 @@ func ExampleNewDir() {
 
 // Create a new file with some content
 func ExampleNewFile() {
-	file := NewFile(t, "test-name", WithContent("content\n"), AsUser(0, 0))
+	file := fs.NewFile(t, "test-name", fs.WithContent("content\n"), fs.AsUser(0, 0))
 	defer file.Remove()
 
 	content, err := ioutil.ReadFile(file.Path())
@@ -38,10 +38,10 @@ func ExampleNewFile() {
 
 // Create a directory and subdirectory with files
 func ExampleWithDir() {
-	dir := NewDir(t, "test-name",
-		WithDir("subdir",
-			WithMode(os.FileMode(0700)),
-			WithFile("file1", "content\n")),
+	dir := fs.NewDir(t, "test-name",
+		fs.WithDir("subdir",
+			fs.WithMode(os.FileMode(0700)),
+			fs.WithFile("file1", "content\n")),
 	)
 	defer dir.Remove()
 }

--- a/golden/example_test.go
+++ b/golden/example_test.go
@@ -1,11 +1,15 @@
-package golden
+package golden_test
 
-var t = &FakeT{}
+import (
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/golden"
+)
 
 func ExampleAssert() {
-	Assert(t, "foo", "foo-content.golden")
+	golden.Assert(&testing.T{}, "foo", "foo-content.golden")
 }
 
 func ExampleAssertBytes() {
-	AssertBytes(t, []byte("foo"), "foo-content.golden")
+	golden.AssertBytes(&testing.T{}, []byte("foo"), "foo-content.golden")
 }

--- a/golden/example_test.go
+++ b/golden/example_test.go
@@ -6,10 +6,12 @@ import (
 	"github.com/gotestyourself/gotestyourself/golden"
 )
 
+var t = &testing.T{}
+
 func ExampleAssert() {
-	golden.Assert(&testing.T{}, "foo", "foo-content.golden")
+	golden.Assert(t, "foo", "foo-content.golden")
 }
 
 func ExampleAssertBytes() {
-	golden.AssertBytes(&testing.T{}, []byte("foo"), "foo-content.golden")
+	golden.AssertBytes(t, []byte("foo"), "foo-content.golden")
 }

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -10,27 +10,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type FakeT struct {
+type fakeT struct {
 	Failed bool
 }
 
-func (t *FakeT) Fatal(_ ...interface{}) {
+func (t *fakeT) Fatal(a ...interface{}) {
 	t.Failed = true
 }
 
-func (t *FakeT) Fatalf(string, ...interface{}) {
+func (t *fakeT) Fatalf(string, ...interface{}) {
 	t.Failed = true
 }
 
-func (t *FakeT) Errorf(_ string, _ ...interface{}) {
+func (t *fakeT) Errorf(_ string, _ ...interface{}) {
 }
 
-func (t *FakeT) FailNow() {
+func (t *fakeT) FailNow() {
 	t.Failed = true
 }
 
 func TestGoldenGetInvalidFile(t *testing.T) {
-	fakeT := new(FakeT)
+	fakeT := new(fakeT)
 
 	Get(fakeT, "/invalid/path")
 	require.True(t, fakeT.Failed)
@@ -42,7 +42,7 @@ func TestGoldenGet(t *testing.T) {
 	filename, clean := setupGoldenFile(t, expected)
 	defer clean()
 
-	fakeT := new(FakeT)
+	fakeT := new(fakeT)
 
 	actual := Get(fakeT, filename)
 	assert.False(t, fakeT.Failed)
@@ -53,7 +53,7 @@ func TestGoldenAssertInvalidContent(t *testing.T) {
 	filename, clean := setupGoldenFile(t, "content")
 	defer clean()
 
-	fakeT := new(FakeT)
+	fakeT := new(fakeT)
 
 	success := Assert(fakeT, "foo", filename)
 	assert.False(t, fakeT.Failed)
@@ -64,7 +64,7 @@ func TestGoldenAssert(t *testing.T) {
 	filename, clean := setupGoldenFile(t, "foo")
 	defer clean()
 
-	fakeT := new(FakeT)
+	fakeT := new(fakeT)
 
 	success := Assert(fakeT, "foo", filename)
 	assert.False(t, fakeT.Failed)

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -14,7 +14,7 @@ type fakeT struct {
 	Failed bool
 }
 
-func (t *fakeT) Fatal(a ...interface{}) {
+func (t *fakeT) Fatal(_ ...interface{}) {
 	t.Failed = true
 }
 

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -2,6 +2,7 @@
   "Vendor": true,
   "Deadline": "2m",
   "Sort": ["linter", "severity", "path"],
+  "Exclude": ["example_test\\.go"],
 
   "Enable": [
     "deadcode",

--- a/icmd/example_test.go
+++ b/icmd/example_test.go
@@ -1,4 +1,6 @@
-package icmd
+package icmd_test
+
+import "github.com/gotestyourself/gotestyourself/icmd"
 
 type fakeTesting struct{}
 
@@ -7,13 +9,13 @@ func (t fakeTesting) Fatalf(string, ...interface{}) {}
 var t = fakeTesting{}
 
 func ExampleRunCommand() {
-	result := RunCommand("bash", "-c", "echo all good")
-	result.Assert(t, Success)
+	result := icmd.RunCommand("bash", "-c", "echo all good")
+	result.Assert(t, icmd.Success)
 }
 
 func ExampleRunCmd() {
-	result := RunCmd(Command("cat", "/does/not/exist"))
-	result.Assert(t, Expected{
+	result := icmd.RunCmd(icmd.Command("cat", "/does/not/exist"))
+	result.Assert(t, icmd.Expected{
 		ExitCode: 1,
 		Err:      "cat: /does/not/exist: No such file or directory",
 	})

--- a/poll/example_test.go
+++ b/poll/example_test.go
@@ -1,12 +1,13 @@
-package poll
+package poll_test
 
 import (
 	"time"
 
+	"github.com/gotestyourself/gotestyourself/poll"
 	"github.com/pkg/errors"
 )
 
-var t TestingT
+var t poll.TestingT
 
 func numOfProcesses() (int, error) {
 	return 0, nil
@@ -15,30 +16,30 @@ func numOfProcesses() (int, error) {
 func ExampleWaitOn() {
 	desired := 10
 
-	check := func(t LogT) Result {
+	check := func(t poll.LogT) poll.Result {
 		actual, err := numOfProcesses()
 		if err != nil {
-			return Error(errors.Wrapf(err, "failed to get number of processes: %s"))
+			return poll.Error(errors.Wrapf(err, "failed to get number of processes: %s"))
 		}
 		if actual == desired {
-			return Success()
+			return poll.Success()
 		}
 		t.Logf("waiting on process count to be %d...", desired)
-		return Continue("number of processes is %d, not %d", actual, desired)
+		return poll.Continue("number of processes is %d, not %d", actual, desired)
 	}
 
-	WaitOn(t, check)
+	poll.WaitOn(t, check)
 }
 
 func isDesiredState() bool { return false }
 func getState() string     { return "" }
 
 func ExampleSettingOp() {
-	check := func(t LogT) Result {
+	check := func(t poll.LogT) poll.Result {
 		if isDesiredState() {
-			return Success()
+			return poll.Success()
 		}
-		return Continue("state is: %s", getState())
+		return poll.Continue("state is: %s", getState())
 	}
-	WaitOn(t, check, WithTimeout(30*time.Second), WithDelay(15*time.Millisecond))
+	poll.WaitOn(t, check, poll.WithTimeout(30*time.Second), poll.WithDelay(15*time.Millisecond))
 }

--- a/skip/example_test.go
+++ b/skip/example_test.go
@@ -1,6 +1,11 @@
-package skip
+package skip_test
 
-var t = &fakeSkipT{}
+import (
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/skip"
+)
+
 var apiVersion = ""
 
 type env struct{}
@@ -14,19 +19,23 @@ func MissingFeature() bool { return false }
 func ExampleIf() {
 	//   --- SKIP: TestName (0.00s)
 	//           skip.go:19: MissingFeature
-	If(t, MissingFeature)
+	skip.If(&testing.T{}, MissingFeature)
 
 	//   --- SKIP: TestName (0.00s)
 	//           skip.go:19: MissingFeature: coming soon
-	If(t, MissingFeature, "coming soon")
+	skip.If(&testing.T{}, MissingFeature, "coming soon")
 }
 
 func ExampleIfCondition() {
 	//   --- SKIP: TestName (0.00s)
 	//           skip.go:19: apiVersion < version("v1.24")
-	IfCondition(t, apiVersion < version("v1.24"))
+	skip.IfCondition(&testing.T{}, apiVersion < version("v1.24"))
 
 	//   --- SKIP: TestName (0.00s)
 	//           skip.go:19: !textenv.hasFeature("build"): coming soon
-	IfCondition(t, !testEnv.hasFeature("build"), "coming soon")
+	skip.IfCondition(&testing.T{}, !testEnv.hasFeature("build"), "coming soon")
+}
+
+func version(v string) string {
+	return v
 }

--- a/skip/example_test.go
+++ b/skip/example_test.go
@@ -16,24 +16,26 @@ var testEnv = env{}
 
 func MissingFeature() bool { return false }
 
+var t = &testing.T{}
+
 func ExampleIf() {
 	//   --- SKIP: TestName (0.00s)
 	//           skip.go:19: MissingFeature
-	skip.If(&testing.T{}, MissingFeature)
+	skip.If(t, MissingFeature)
 
 	//   --- SKIP: TestName (0.00s)
 	//           skip.go:19: MissingFeature: coming soon
-	skip.If(&testing.T{}, MissingFeature, "coming soon")
+	skip.If(t, MissingFeature, "coming soon")
 }
 
 func ExampleIfCondition() {
 	//   --- SKIP: TestName (0.00s)
 	//           skip.go:19: apiVersion < version("v1.24")
-	skip.IfCondition(&testing.T{}, apiVersion < version("v1.24"))
+	skip.IfCondition(t, apiVersion < version("v1.24"))
 
 	//   --- SKIP: TestName (0.00s)
 	//           skip.go:19: !textenv.hasFeature("build"): coming soon
-	skip.IfCondition(&testing.T{}, !testEnv.hasFeature("build"), "coming soon")
+	skip.IfCondition(t, !testEnv.hasFeature("build"), "coming soon")
 }
 
 func version(v string) string {


### PR DESCRIPTION
That way it is closer to the real usage.

We could also have the actual `test` using those (to ensure we can only test exported stuff from the package) but didn't go that far yet 👼 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>