### PR TITLE
Updateand cleanup icmd

### DIFF
--- a/icmd/example_test.go
+++ b/icmd/example_test.go
@@ -12,7 +12,7 @@ func ExampleRunCommand() {
 }
 
 func ExampleRunCmd() {
-	result := RunCmd(Command("cat /does/not/exist"))
+	result := RunCmd(Command("cat", "/does/not/exist"))
 	result.Assert(t, Expected{
 		ExitCode: 1,
 		Err:      "cat: /does/not/exist: No such file or directory",

--- a/icmd/exitcode.go
+++ b/icmd/exitcode.go
@@ -7,9 +7,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GetExitCode returns the ExitStatus of a process from the error returned by
+// getExitCode returns the ExitStatus of a process from the error returned by
 // exec.Run(). If the exit status could not be parsed an error is returned.
-func GetExitCode(err error) (int, error) {
+func getExitCode(err error) (int, error) {
 	if exiterr, ok := err.(*exec.ExitError); ok {
 		if procExit, ok := exiterr.Sys().(syscall.WaitStatus); ok {
 			return procExit.ExitStatus(), nil
@@ -22,7 +22,7 @@ func processExitCode(err error) (exitCode int) {
 	if err == nil {
 		return 0
 	}
-	exitCode, exiterr := GetExitCode(err)
+	exitCode, exiterr := getExitCode(err)
 	if exiterr != nil {
 		// TODO: Fix this so we check the error's text.
 		// we've failed to retrieve exit code, so we set it to 127

--- a/icmd/ops.go
+++ b/icmd/ops.go
@@ -1,0 +1,4 @@
+package icmd
+
+// CmdOp is an operation which modified a Cmd structure used to execute commands
+type CmdOp func(*Cmd)


### PR DESCRIPTION
* fix some docs and examples
* add `PathOp` as a type. I think we can add some more functions here soon

Also unexport a few things that I think don't need to be exported. This is technically a breaking change, but I doubt anyone else is really using this library yet, so hopefully we can still fix this problem without having to tag v2.