### PR TITLE
Add env package

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -1,0 +1,58 @@
+/*Package env provides functions to test code that read environment variables
+ */
+package env
+
+import (
+	"os"
+	"strings"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Patch changes the value of an environment variable, and returns a
+// function which will reset the the value of that variable back to the
+// previous state.
+func Patch(t require.TestingT, key, value string) func() {
+	oldValue, ok := os.LookupEnv(key)
+	require.NoError(t, os.Setenv(key, value))
+	return func() {
+		if !ok {
+			require.NoError(t, os.Unsetenv(key))
+			return
+		}
+		require.NoError(t, os.Setenv(key, oldValue))
+	}
+}
+
+// PatchAll sets the environment to env, and returns a function which will
+// reset the environment back to the previous state.
+func PatchAll(t require.TestingT, env map[string]string) func() {
+	oldEnv := os.Environ()
+	os.Clearenv()
+
+	for key, value := range env {
+		require.NoError(t, os.Setenv(key, value))
+	}
+	return func() {
+		os.Clearenv()
+		for key, oldVal := range ToMap(oldEnv) {
+			require.NoError(t, os.Setenv(key, oldVal))
+		}
+	}
+}
+
+// ToMap takes a list of strings in the format returned by os.Environ() and
+// returns a mapping of keys to values.
+func ToMap(env []string) map[string]string {
+	result := map[string]string{}
+	for _, raw := range env {
+		parts := strings.SplitN(raw, "=", 2)
+		switch len(parts) {
+		case 1:
+			result[raw] = ""
+		case 2:
+			result[parts[0]] = parts[1]
+		}
+	}
+	return result
+}

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -1,0 +1,62 @@
+package env
+
+import (
+	"os"
+	"testing"
+
+	"sort"
+
+	"github.com/gotestyourself/gotestyourself/skip"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPatchFromUnset(t *testing.T) {
+	key, value := "FOO_IS_UNSET", "VALUE"
+	revert := Patch(t, key, value)
+
+	assert.Equal(t, value, os.Getenv(key))
+	revert()
+	_, isSet := os.LookupEnv(key)
+	assert.False(t, isSet)
+}
+
+func TestPatch(t *testing.T) {
+	skip.IfCondition(t, os.Getenv("PATH") == "")
+	oldVal := os.Getenv("PATH")
+
+	key, value := "PATH", "NEWVALUE"
+	revert := Patch(t, key, value)
+
+	assert.Equal(t, value, os.Getenv(key))
+	revert()
+	assert.Equal(t, oldVal, os.Getenv(key))
+}
+
+func TestPatchAll(t *testing.T) {
+	oldEnv := os.Environ()
+	newEnv := map[string]string{
+		"FIRST": "STARS",
+		"THEN":  "MOON",
+	}
+
+	revert := PatchAll(t, newEnv)
+
+	actual := os.Environ()
+	sort.Strings(actual)
+	assert.Equal(t, []string{"FIRST=STARS", "THEN=MOON"}, actual)
+
+	revert()
+	assert.Equal(t, sorted(oldEnv), sorted(os.Environ()))
+}
+
+func sorted(source []string) []string {
+	sort.Strings(source)
+	return source
+}
+
+func TestToMap(t *testing.T) {
+	source := []string{"key=value", "novaluekey"}
+	actual := ToMap(source)
+	expected := map[string]string{"key": "value", "novaluekey": ""}
+	assert.Equal(t, expected, actual)
+}

--- a/env/example_test.go
+++ b/env/example_test.go
@@ -1,0 +1,18 @@
+package env
+
+import "testing"
+
+var t = &testing.T{}
+
+// Patch an environment variable and defer to return to the previous state
+func ExamplePatch() {
+	defer Patch(t, "PATH", "/custom/path")()
+}
+
+// Patch all environment variables
+func ExamplePatchAll() {
+	defer PatchAll(t, map[string]string{
+		"ONE": "FOO",
+		"TWO": "BAR",
+	})()
+}


### PR DESCRIPTION
Replaces #21 

Add an `env` package for patching environment variables, and also converting the output of `os.Environ()` into a map.