### PR TITLE
Support go 1.9

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,16 +30,33 @@ jobs:
             docker build -f $dockerfile --tag cli-linter:$CIRCLE_BUILD_NUM .
             docker run --rm cli-linter:$CIRCLE_BUILD_NUM
 
-  test:
+  test-1.9:
     working_directory: /work
     docker: [{image: 'docker:17.06-git'}]
     steps:
       - checkout
       - setup_remote_docker
       - run:
-          name: "Unit Test"
+          name: "Unit Test GO 1.9"
           command: |
             dockerfile=dobifiles/Dockerfile
+            echo "COPY . ." >> $dockerfile
+            docker build -f $dockerfile --tag cli-builder:$CIRCLE_BUILD_NUM .
+            docker run --name \
+                test-$CIRCLE_BUILD_NUM cli-builder:$CIRCLE_BUILD_NUM \
+                bash -c 'dep ensure && scripts/binary-testsum && scripts/test-unit'
+
+  test-1.8:
+    working_directory: /work
+    docker: [{image: 'docker:17.06-git'}]
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: "Unit Test GO 1.8"
+          command: |
+            dockerfile=dobifiles/Dockerfile
+            sed -i -e 's/FROM\s\+golang.*/FROM golang:1.8.3-alpine/' $dockerfile
             echo "COPY . ." >> $dockerfile
             docker build -f $dockerfile --tag cli-builder:$CIRCLE_BUILD_NUM .
             docker run --name \
@@ -51,4 +68,5 @@ workflows:
   ci:
     jobs:
       - lint
-      - test
+      - test-1.8
+      - test-1.9

--- a/dobifiles/Dockerfile
+++ b/dobifiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM    golang:1.8.3-alpine
+FROM    golang:1.9-alpine
 
 RUN     apk add -U curl git bash
 

--- a/dobifiles/Dockerfile.lint
+++ b/dobifiles/Dockerfile.lint
@@ -1,8 +1,8 @@
-FROM    golang:1.8.3-alpine
+FROM    golang:1.9-alpine
 
 RUN     apk add -U git
 
-ARG     GOMETALINTER_SHA=4306381615a2ba2a207f8fcea02c08c6b2b0803f
+ARG     GOMETALINTER_SHA=bfcc1d6942136fd86eb6f1a6fb328de8398fbd80
 RUN     go get -d github.com/alecthomas/gometalinter && \
         cd /go/src/github.com/alecthomas/gometalinter && \
         git checkout -q "$GOMETALINTER_SHA" && \

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -14,7 +14,7 @@ type FakeT struct {
 	Failed bool
 }
 
-func (t *FakeT) Fatal(a ...interface{}) {
+func (t *FakeT) Fatal(_ ...interface{}) {
 	t.Failed = true
 }
 

--- a/skip/skip_go18.go
+++ b/skip/skip_go18.go
@@ -1,0 +1,17 @@
+// +build !go1.9,!go.10,!go.11,!go1.12
+
+package skip
+
+import "strings"
+
+func getSourceLinesRange(line int, _ int) (int, int) {
+	firstLine := line - maxContextLines
+	if firstLine < 0 {
+		firstLine = 0
+	}
+	return firstLine, line
+}
+
+func getSource(lines []string, i int) string {
+	return strings.Join(lines[len(lines)-i-1:], "\n")
+}

--- a/skip/skip_go19.go
+++ b/skip/skip_go19.go
@@ -1,0 +1,17 @@
+// +build go1.9
+
+package skip
+
+import "strings"
+
+func getSourceLinesRange(line int, lines int) (int, int) {
+	lastLine := line + maxContextLines
+	if lastLine > lines {
+		lastLine = lines
+	}
+	return line - 1, lastLine
+}
+
+func getSource(lines []string, i int) string {
+	return strings.Join(lines[:i], "\n")
+}


### PR DESCRIPTION
Also test against both 1.9 and 1.8

It looks like they made a change to the line number reported by `runtime.Callers()`. For multiline strings it's now reporting the first line instead of the last line. So I've updated `skip.go` to account for that.

Also set circle to run tests against both 1.8 and 1.9