### PR TITLE
support absolute paths to golden files

### DIFF
--- a/golden/golden.go
+++ b/golden/golden.go
@@ -26,6 +26,9 @@ func Get(t require.TestingT, filename string) []byte {
 
 // Path returns the full path to a golden file
 func Path(filename string) string {
+	if filepath.IsAbs(filename) {
+		return filename
+	}
 	return filepath.Join("testdata", filename)
 }
 

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gotestyourself/gotestyourself/fs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,6 +35,15 @@ func TestGoldenGetInvalidFile(t *testing.T) {
 
 	Get(fakeT, "/invalid/path")
 	require.True(t, fakeT.Failed)
+}
+
+func TestGoldenGetAbsolutePath(t *testing.T) {
+	file := fs.NewFile(t, "abs-test", fs.WithContent("content\n"))
+	defer file.Remove()
+	fakeT := new(fakeT)
+
+	Get(fakeT, file.Path())
+	require.False(t, fakeT.Failed)
 }
 
 func TestGoldenGet(t *testing.T) {


### PR DESCRIPTION
Allows pointing to absolute golden files.

I need this when I want to point to an existing file or when I want to use `https://github.com/gotestyourself/gotestyourself/tree/master/fs` to setup a more complex set of testing files.