### PR TITLE
Improve skip package

### DIFF
--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -20,8 +20,8 @@ const maxContextLines = 20
 // GetCondition returns the condition string by reading it from the file
 // identified in the callstack. In golang 1.9 the line number changed from
 // being the line where the statement ended to the line where the statement began.
-func GetCondition(argPos int) (string, error) {
-	lines, err := getSourceLines()
+func GetCondition(stackIndex int, argPos int) (string, error) {
+	lines, err := getSourceLines(stackIndex)
 	if err != nil {
 		return "", err
 	}
@@ -39,8 +39,7 @@ func GetCondition(argPos int) (string, error) {
 // few preceding lines. To properly parse the AST a complete statement is
 // required, and that statement may be split across multiple lines, so include
 // up to maxContextLines.
-func getSourceLines() ([]string, error) {
-	const stackIndex = 3
+func getSourceLines(stackIndex int) ([]string, error) {
 	_, filename, lineNum, ok := runtime.Caller(stackIndex)
 	if !ok {
 		return nil, errors.New("failed to get caller info")

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -1,0 +1,70 @@
+package source
+
+import (
+	"bytes"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"runtime"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// maxContextLines is the maximum number of lines to scan for a complete
+// expression
+const maxContextLines = 20
+
+// GetCondition returns the condition string by reading it from the file
+// identified in the callstack. In golang 1.9 the line number changed from
+// being the line where the statement ended to the line where the statement began.
+func GetCondition(argPos int) (string, error) {
+	lines, err := getSourceLines()
+	if err != nil {
+		return "", err
+	}
+
+	for i := range lines {
+		node, err := parser.ParseExpr(getSource(lines, i))
+		if err == nil {
+			return getArgSourceFromAST(node, argPos)
+		}
+	}
+	return "", errors.Wrapf(err, "failed to parse source")
+}
+
+// getSourceLines returns the source line which called skip.If() along with a
+// few preceding lines. To properly parse the AST a complete statement is
+// required, and that statement may be split across multiple lines, so include
+// up to maxContextLines.
+func getSourceLines() ([]string, error) {
+	const stackIndex = 3
+	_, filename, lineNum, ok := runtime.Caller(stackIndex)
+	if !ok {
+		return nil, errors.New("failed to get caller info")
+	}
+
+	raw, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read source file: %s", filename)
+	}
+
+	lines := strings.Split(string(raw), "\n")
+	if len(lines) < lineNum {
+		return nil, errors.Errorf("file %s does not have line %d", filename, lineNum)
+	}
+	firstLine, lastLine := getSourceLinesRange(lineNum, len(lines))
+	return lines[firstLine:lastLine], nil
+}
+
+func getArgSourceFromAST(node ast.Expr, argPos int) (string, error) {
+	switch expr := node.(type) {
+	case *ast.CallExpr:
+		buf := new(bytes.Buffer)
+		err := format.Node(buf, token.NewFileSet(), expr.Args[argPos])
+		return buf.String(), err
+	}
+	return "", errors.New("unexpected ast")
+}

--- a/internal/source/source_go18.go
+++ b/internal/source/source_go18.go
@@ -1,6 +1,6 @@
 // +build !go1.9,!go.10,!go.11,!go1.12
 
-package skip
+package source
 
 import "strings"
 

--- a/internal/source/source_go19.go
+++ b/internal/source/source_go19.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-package skip
+package source
 
 import "strings"
 

--- a/skip/skip_test.go
+++ b/skip/skip_test.go
@@ -32,7 +32,7 @@ func version(v string) string {
 func TestIfCondition(t *testing.T) {
 	skipT := &fakeSkipT{}
 	apiVersion := "v1.4"
-	IfCondition(skipT, apiVersion < version("v1.6"))
+	If(skipT, apiVersion < version("v1.6"))
 
 	assert.Equal(t, `apiVersion < version("v1.6")`, skipT.reason)
 	assert.Len(t, skipT.logs, 0)
@@ -41,7 +41,7 @@ func TestIfCondition(t *testing.T) {
 func TestIfConditionWithMessage(t *testing.T) {
 	skipT := &fakeSkipT{}
 	apiVersion := "v1.4"
-	IfCondition(skipT, apiVersion < "v1.6", "see notes")
+	If(skipT, apiVersion < "v1.6", "see notes")
 
 	assert.Equal(t, `apiVersion < "v1.6": see notes`, skipT.reason)
 	assert.Len(t, skipT.logs, 0)
@@ -50,7 +50,7 @@ func TestIfConditionWithMessage(t *testing.T) {
 func TestIfConditionMultiline(t *testing.T) {
 	skipT := &fakeSkipT{}
 	apiVersion := "v1.4"
-	IfCondition(
+	If(
 		skipT,
 		apiVersion < "v1.6")
 
@@ -61,7 +61,7 @@ func TestIfConditionMultiline(t *testing.T) {
 func TestIfConditionMultilineWithMessage(t *testing.T) {
 	skipT := &fakeSkipT{}
 	apiVersion := "v1.4"
-	IfCondition(
+	If(
 		skipT,
 		apiVersion < "v1.6",
 		"see notes")
@@ -72,7 +72,7 @@ func TestIfConditionMultilineWithMessage(t *testing.T) {
 
 func TestIfConditionNoSkip(t *testing.T) {
 	skipT := &fakeSkipT{}
-	IfCondition(skipT, false)
+	If(skipT, false)
 
 	assert.Equal(t, "", skipT.reason)
 	assert.Len(t, skipT.logs, 0)


### PR DESCRIPTION
Moves the source code inspection from `skip` into an internal package, so it can be re-used by other packages (assert).

Deprecates `IfCondition()`, instead have `If()` accept both types.