### PR TITLE
Add `assert` package

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,10 +4,6 @@
   version = "0.8.0"
 
 [[constraint]]
-  name = "github.com/stretchr/testify"
-  version = "1.1.4"
-
-[[constraint]]
   name = "github.com/pmezard/go-difflib"
   version = "1.0.0"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -14,3 +14,8 @@
 [[constraint]]
   name = "github.com/spf13/pflag"
   version = "1.0.0"
+
+[[constraint]]
+  name = "github.com/google/go-cmp"
+  version = "0.1.0"
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ patterns.
 
 ## Packages
 
+* [assert](http://godoc.org/github.com/gotestyourself/gotestyourself/assert) -
+  compare values and fail the test when the comparison fails
 * [env](http://godoc.org/github.com/gotestyourself/gotestyourself/env) -
   test code that uses environment variables
 * [fs](http://godoc.org/github.com/gotestyourself/gotestyourself/fs) -
@@ -27,9 +29,4 @@ patterns.
 
 ## Related
 
-* [testify/assert](https://godoc.org/github.com/stretchr/testify/assert) and 
-  [testify/require](https://godoc.org/github.com/stretchr/testify/require) -
-  assertion libraries with common assertions
 * [maxbrunsfeld/counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) - generate fakes for interfaces
-* [testify/suite](https://godoc.org/github.com/stretchr/testify/suite) - 
-  group test into suites to share common setup/teardown logic

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -1,0 +1,1 @@
+package assert

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -127,7 +127,8 @@ func (t Tester) assert(failer func(), comparison BoolOrComparison, msgAndArgs ..
 			t.t.Log(err.Error())
 		}
 
-		t.t.Log(format.WithCustomMessage(failureMessage+source, msgAndArgs...))
+		msg := " is false"
+		t.t.Log(format.WithCustomMessage(failureMessage+source+msg, msgAndArgs...))
 		failer()
 		return false
 

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -1,1 +1,161 @@
+/*Package assert provides assertions and checks for comparing expected values to
+actual values, and printing helpful failure messages.
+*/
 package assert
+
+import (
+	"fmt"
+
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/gotestyourself/gotestyourself/internal/format"
+	"github.com/gotestyourself/gotestyourself/internal/source"
+)
+
+// BoolOrComparison can be a bool, Comparison, or CompareFunc, other types will
+// panic
+type BoolOrComparison interface{}
+
+// Comparison provides a compare method for comparing values
+type Comparison interface {
+	// Compare performs a comparison and returns true if actual value matches
+	// the expected value. If the values do not match it returns a message
+	// with details about why it failNowed.
+	Compare() (success bool, message string)
+}
+
+// CompareFunc is a Comparison.Compare()
+type CompareFunc func() (success bool, message string)
+
+// TestingT is the subset of testing.T used by the assert package
+type TestingT interface {
+	FailNow()
+	Fail()
+	Log(args ...interface{})
+	Helper()
+}
+
+// Tester wraps a TestingT and provides assertions and checks
+type Tester struct {
+	t          TestingT
+	stackIndex int
+	argPos     int
+}
+
+// stackIndex = Assert()/Check(), assert()
+const stackIndex = 2
+
+const failureMessage = "assertion failed: "
+
+// New returns a new Tester for asserting and checking values
+func New(t TestingT) Tester {
+	return Tester{t: t, stackIndex: stackIndex, argPos: 0}
+}
+
+// Assert performs a comparison, marks the test as having failed if the comparison
+// returns false, and stops execution immediately.
+func (t Tester) Assert(comparison BoolOrComparison, msgAndArgs ...interface{}) {
+	t.t.Helper()
+	t.assert(t.t.FailNow, comparison, msgAndArgs...)
+}
+
+func (t Tester) assert(failer func(), comparison BoolOrComparison, msgAndArgs ...interface{}) bool {
+	t.t.Helper()
+	switch check := comparison.(type) {
+	case bool:
+		if check {
+			return true
+		}
+		source, err := source.GetCondition(t.stackIndex, t.argPos)
+		if err != nil {
+			t.t.Log(err.Error())
+		}
+
+		t.t.Log(format.WithCustomMessage(failureMessage+source, msgAndArgs...))
+		failer()
+		return false
+
+	case Comparison:
+		return runCompareFunc(failer, t.t, check.Compare, msgAndArgs...)
+
+	case func() (success bool, message string):
+		return runCompareFunc(failer, t.t, check, msgAndArgs...)
+
+	case CompareFunc:
+		return runCompareFunc(failer, t.t, check, msgAndArgs...)
+
+	default:
+		panic(fmt.Sprintf("invalid type for condition arg: %T", comparison))
+	}
+}
+
+func runCompareFunc(failer func(), t TestingT, f CompareFunc, msgAndArgs ...interface{}) bool {
+	t.Helper()
+	if success, message := f(); !success {
+		t.Log(format.WithCustomMessage(failureMessage+message, msgAndArgs...))
+		failer()
+		return false
+	}
+	return true
+}
+
+// Check performs a comparison and marks the test as having failed if the comparison
+// returns false. Returns the result of the comparison.
+func (t Tester) Check(comparison BoolOrComparison, msgAndArgs ...interface{}) bool {
+	t.t.Helper()
+	return t.assert(t.t.Fail, comparison, msgAndArgs...)
+}
+
+// NoError fails the test immediately if the last arg is a non-nil error
+func (t Tester) NoError(args ...interface{}) {
+	t.t.Helper()
+	if len(args) == 0 {
+		return
+	}
+	switch lastArg := args[len(args)-1].(type) {
+	case error:
+		t.t.Log(fmt.Sprintf("expected no error, got %s", lastArg))
+		t.t.FailNow()
+	case nil:
+	default:
+		t.t.Log(fmt.Sprintf("last argument to NoError() must be an error, got %T", lastArg))
+		t.t.FailNow()
+	}
+}
+
+// Equal uses the == operator to assert two values are the equal
+func (t Tester) Equal(x, y interface{}, msgAndArgs ...interface{}) {
+	t.t.Helper()
+	t.assert(t.t.FailNow, cmp.Equal(x, y), msgAndArgs...)
+}
+
+// Assert fails the test immediate if comparison is not a success
+func Assert(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) {
+	t.Helper()
+	newPackageScopeTester(t).Assert(comparison, msgAndArgs...)
+}
+
+// Check performs a comparison and marks the test as having failed if the comparison
+// returns false. Returns the result of the comparison.
+func Check(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) bool {
+	t.Helper()
+	return newPackageScopeTester(t).Check(comparison, msgAndArgs...)
+}
+
+// NoError fails the test immediately if the last arg is a non-nil error
+func NoError(t TestingT, args ...interface{}) {
+	t.Helper()
+	newPackageScopeTester(t).NoError(args...)
+}
+
+// Equal uses the == operator to assert two values are the equal
+func Equal(t TestingT, x, y interface{}, msgAndArgs ...interface{}) {
+	t.Helper()
+	newPackageScopeTester(t).Equal(x, y, msgAndArgs...)
+}
+
+// newPackageScopeTester returns a Tester appropriate for package level functions.
+// The tester has stackIndex+1 to accommodate the extra function in the stack, and
+// argPos 1 because package level functions accept testing.T as the first argument
+func newPackageScopeTester(t TestingT) Tester {
+	return Tester{t: t, stackIndex: stackIndex + 1, argPos: 1}
+}

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -31,6 +31,9 @@ type TestingT interface {
 	FailNow()
 	Fail()
 	Log(args ...interface{})
+}
+
+type helperT interface {
 	Helper()
 }
 
@@ -54,12 +57,16 @@ func New(t TestingT) Tester {
 // Assert performs a comparison, marks the test as having failed if the comparison
 // returns false, and stops execution immediately.
 func (t Tester) Assert(comparison BoolOrComparison, msgAndArgs ...interface{}) {
-	t.t.Helper()
+	if ht, ok := t.t.(helperT); ok {
+		ht.Helper()
+	}
 	t.assert(t.t.FailNow, comparison, msgAndArgs...)
 }
 
 func (t Tester) assert(failer func(), comparison BoolOrComparison, msgAndArgs ...interface{}) bool {
-	t.t.Helper()
+	if ht, ok := t.t.(helperT); ok {
+		ht.Helper()
+	}
 	switch check := comparison.(type) {
 	case bool:
 		if check {
@@ -89,7 +96,9 @@ func (t Tester) assert(failer func(), comparison BoolOrComparison, msgAndArgs ..
 }
 
 func runCompareFunc(failer func(), t TestingT, f CompareFunc, msgAndArgs ...interface{}) bool {
-	t.Helper()
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
 	if success, message := f(); !success {
 		t.Log(format.WithCustomMessage(failureMessage+message, msgAndArgs...))
 		failer()
@@ -101,46 +110,60 @@ func runCompareFunc(failer func(), t TestingT, f CompareFunc, msgAndArgs ...inte
 // Check performs a comparison and marks the test as having failed if the comparison
 // returns false. Returns the result of the comparison.
 func (t Tester) Check(comparison BoolOrComparison, msgAndArgs ...interface{}) bool {
-	t.t.Helper()
+	if ht, ok := t.t.(helperT); ok {
+		ht.Helper()
+	}
 	return t.assert(t.t.Fail, comparison, msgAndArgs...)
 }
 
 // NoError fails the test immediately if the last arg is a non-nil error.
 // This is equivalent to Assert(cmp.NoError(err))
 func (t Tester) NoError(args ...interface{}) {
-	t.t.Helper()
+	if ht, ok := t.t.(helperT); ok {
+		ht.Helper()
+	}
 	t.assert(t.t.FailNow, cmp.NoError(args...))
 }
 
 // Equal uses the == operator to assert two values are the equal.
 // This is equivalent to Assert(cmp.Equal(x, y))
 func (t Tester) Equal(x, y interface{}, msgAndArgs ...interface{}) {
-	t.t.Helper()
+	if ht, ok := t.t.(helperT); ok {
+		ht.Helper()
+	}
 	t.assert(t.t.FailNow, cmp.Equal(x, y), msgAndArgs...)
 }
 
 // Assert fails the test immediate if comparison is not a success
 func Assert(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) {
-	t.Helper()
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
 	newPackageScopeTester(t).Assert(comparison, msgAndArgs...)
 }
 
 // Check performs a comparison and marks the test as having failed if the comparison
 // returns false. Returns the result of the comparison.
 func Check(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) bool {
-	t.Helper()
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
 	return newPackageScopeTester(t).Check(comparison, msgAndArgs...)
 }
 
 // NoError fails the test immediately if the last arg is a non-nil error
 func NoError(t TestingT, args ...interface{}) {
-	t.Helper()
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
 	newPackageScopeTester(t).NoError(args...)
 }
 
 // Equal uses the == operator to assert two values are the equal
 func Equal(t TestingT, x, y interface{}, msgAndArgs ...interface{}) {
-	t.Helper()
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
 	newPackageScopeTester(t).Equal(x, y, msgAndArgs...)
 }
 

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -105,24 +105,15 @@ func (t Tester) Check(comparison BoolOrComparison, msgAndArgs ...interface{}) bo
 	return t.assert(t.t.Fail, comparison, msgAndArgs...)
 }
 
-// NoError fails the test immediately if the last arg is a non-nil error
+// NoError fails the test immediately if the last arg is a non-nil error.
+// This is equivalent to Assert(cmp.NoError(err))
 func (t Tester) NoError(args ...interface{}) {
 	t.t.Helper()
-	if len(args) == 0 {
-		return
-	}
-	switch lastArg := args[len(args)-1].(type) {
-	case error:
-		t.t.Log(fmt.Sprintf("expected no error, got %s", lastArg))
-		t.t.FailNow()
-	case nil:
-	default:
-		t.t.Log(fmt.Sprintf("last argument to NoError() must be an error, got %T", lastArg))
-		t.t.FailNow()
-	}
+	t.assert(t.t.FailNow, cmp.NoError(args...))
 }
 
-// Equal uses the == operator to assert two values are the equal
+// Equal uses the == operator to assert two values are the equal.
+// This is equivalent to Assert(cmp.Equal(x, y))
 func (t Tester) Equal(x, y interface{}, msgAndArgs ...interface{}) {
 	t.t.Helper()
 	t.assert(t.t.FailNow, cmp.Equal(x, y), msgAndArgs...)

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -1,5 +1,52 @@
 /*Package assert provides assertions and checks for comparing expected values to
-actual values, and printing helpful failure messages.
+actual values. When an assertion or check fails a helpful error message is
+printed.
+
+Assert and Check
+
+Assert() and Check() both accept a Comparison, and fail the test when the
+comparison fails. The one difference is that Assert() will end the test execution
+immediately (using t.FailNow()) whereas Check() will return the value of the
+comparison, then proceed with the rest of the test case (using t.Fail()).
+
+Example Usage
+
+The example below shows assert used with some common types.
+
+
+	import (
+	    "testing"
+
+	    "github.com/gotestyourself/gotestyourself/assert"
+	    "github.com/gotestyourself/gotestyourself/assert/cmp"
+	)
+
+	func TestEverything(t *testing.T) {
+	    // booleans
+	    assert.Assert(t, isOk)
+	    assert.Assert(t, !missing)
+
+	    // primitives
+	    assert.Equal(t, count, 1)
+	    assert.Equal(t, msg, "the message")
+
+	    // errors
+	    assert.NoError(t, closer.Close())
+	    assert.Assert(t, cmp.Error(err, "the exact error message"))
+	    assert.Assert(t, cmp.ErrorContains(err, "includes this"))
+
+	    // complex types
+	    assert.Assert(t, cmp.Len(items, 3))
+	    assert.Assert(t, cmp.Contains(mapping, "key"))
+	    assert.Assert(t, cmp.Compare(result, myStruct{name: "title"}))
+	}
+
+Comparisons
+
+https://godoc.org/github.com/gotestyourself/gotestyourself/assert/cmp provides
+many common comparisons. For less common tests, a custom comparisons can be
+written.
+
 */
 package assert
 
@@ -15,7 +62,10 @@ import (
 // panic
 type BoolOrComparison interface{}
 
-// Comparison provides a compare method for comparing values
+// Comparison provides a compare method for comparing values.
+//
+// https://godoc.org/github.com/gotestyourself/gotestyourself/assert/cmp
+// provides many commonly used Comparisons.
 type Comparison interface {
 	// Compare performs a comparison and returns true if actual value matches
 	// the expected value. If the values do not match it returns a message

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -173,13 +173,13 @@ func (t Tester) Check(comparison BoolOrComparison, msgAndArgs ...interface{}) bo
 	return t.assert(t.t.Fail, comparison, msgAndArgs...)
 }
 
-// NoError fails the test immediately if the last arg is a non-nil error.
-// This is equivalent to Assert(cmp.NoError(err))
-func (t Tester) NoError(args ...interface{}) {
+// NilError fails the test immediately if the last arg is a non-nil error.
+// This is equivalent to Assert(cmp.NilError(err))
+func (t Tester) NilError(arg interface{}, args ...interface{}) {
 	if ht, ok := t.t.(helperT); ok {
 		ht.Helper()
 	}
-	t.assert(t.t.FailNow, cmp.NoError(args...))
+	t.assert(t.t.FailNow, cmp.NilError(arg, args...))
 }
 
 // Equal uses the == operator to assert two values are equal and fails the test
@@ -210,12 +210,12 @@ func Check(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) b
 	return newPackageScopeTester(t).Check(comparison, msgAndArgs...)
 }
 
-// NoError fails the test immediately if the last arg is a non-nil error.
-func NoError(t TestingT, args ...interface{}) {
+// NilError fails the test immediately if the last arg is a non-nil error.
+func NilError(t TestingT, arg interface{}, args ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	newPackageScopeTester(t).NoError(args...)
+	newPackageScopeTester(t).NilError(arg, args...)
 }
 
 // Equal uses the == operator to assert two values are equal, and fails the test

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -6,7 +6,7 @@ Assert and Check
 
 Assert() and Check() both accept a Comparison, and fail the test when the
 comparison fails. The one difference is that Assert() will end the test execution
-immediately (using t.FailNow()) whereas Check() will fail the test (using t.Fail())
+immediately (using t.FailNow()) whereas Check() will fail the test (using t.Fail()),
 return the value of the comparison, then proceed with the rest of the test case.
 
 Example Usage
@@ -18,7 +18,7 @@ The example below shows assert used with some common types.
 	    "testing"
 
 	    "github.com/gotestyourself/gotestyourself/assert"
-	    "github.com/gotestyourself/gotestyourself/assert/cmp"
+	    is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	)
 
 	func TestEverything(t *testing.T) {
@@ -32,18 +32,18 @@ The example below shows assert used with some common types.
 	    assert.Assert(t, total != 10) // NotEqual
 
 	    // errors
-	    assert.NoError(t, closer.Close())
-	    assert.Assert(t, cmp.Error(err, "the exact error message"))
-	    assert.Assert(t, cmp.ErrorContains(err, "includes this"))
+	    assert.NilError(t, closer.Close())
+	    assert.Assert(t, is.Error(err, "the exact error message"))
+	    assert.Assert(t, is.ErrorContains(err, "includes this"))
 
 	    // complex types
-	    assert.Assert(t, cmp.Len(items, 3))
+	    assert.Assert(t, is.Len(items, 3))
 	    assert.Assert(t, len(sequence) != 0) // NotEmpty
-	    assert.Assert(t, cmp.Contains(mapping, "key"))
-	    assert.Assert(t, cmp.Compare(result, myStruct{name: "title"}))
+	    assert.Assert(t, is.Contains(mapping, "key"))
+	    assert.Assert(t, is.Compare(result, myStruct{Name: "title"}))
 
 	    // pointers and interface
-	    assert.Assert(t, cmp.Nil(ref))
+	    assert.Assert(t, is.Nil(ref))
 	    assert.Assert(t, ref != nil) // NotNil
 	}
 
@@ -74,7 +74,7 @@ import (
 	"github.com/gotestyourself/gotestyourself/internal/source"
 )
 
-// BoolOrComparison can be a bool, or Comparison, other types will panic
+// BoolOrComparison can be a bool, or Comparison, other types will panic.
 type BoolOrComparison interface{}
 
 // Comparison is a function which compares values and returns true if the actual
@@ -82,7 +82,7 @@ type BoolOrComparison interface{}
 // with details about why it failed.
 //
 // https://godoc.org/github.com/gotestyourself/gotestyourself/assert/cmp
-// provides many commonly used Comparisons.
+// provides many general purpose Comparisons.
 type Comparison func() (success bool, message string)
 
 // TestingT is the subset of testing.T used by the assert package
@@ -108,7 +108,7 @@ const stackIndex = 2
 
 const failureMessage = "assertion failed: "
 
-// New returns a new Tester for asserting and checking values
+// New returns a new Tester for asserting and checking values.
 func New(t TestingT) Tester {
 	return Tester{t: t, stackIndex: stackIndex, argPos: 0}
 }
@@ -182,7 +182,8 @@ func (t Tester) NoError(args ...interface{}) {
 	t.assert(t.t.FailNow, cmp.NoError(args...))
 }
 
-// Equal uses the == operator to assert two values are the equal.
+// Equal uses the == operator to assert two values are equal and fails the test
+// if they are not equal.
 // This is equivalent to Assert(cmp.Equal(x, y))
 func (t Tester) Equal(x, y interface{}, msgAndArgs ...interface{}) {
 	if ht, ok := t.t.(helperT); ok {
@@ -191,7 +192,8 @@ func (t Tester) Equal(x, y interface{}, msgAndArgs ...interface{}) {
 	t.assert(t.t.FailNow, cmp.Equal(x, y), msgAndArgs...)
 }
 
-// Assert fails the test immediate if comparison is not a success
+// Assert performs a comparison and fails the test immediate if the comparison
+// is not a success.
 func Assert(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
@@ -208,7 +210,7 @@ func Check(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) b
 	return newPackageScopeTester(t).Check(comparison, msgAndArgs...)
 }
 
-// NoError fails the test immediately if the last arg is a non-nil error
+// NoError fails the test immediately if the last arg is a non-nil error.
 func NoError(t TestingT, args ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
@@ -216,7 +218,8 @@ func NoError(t TestingT, args ...interface{}) {
 	newPackageScopeTester(t).NoError(args...)
 }
 
-// Equal uses the == operator to assert two values are the equal
+// Equal uses the == operator to assert two values are equal, and fails the test
+// if they are not equal.
 func Equal(t TestingT, x, y interface{}, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -156,8 +156,6 @@ func TestTesterNoErrorWithMultiArgFailure(t *testing.T) {
 }
 
 func TestTesterCheckFailure(t *testing.T) {
-	t.Skip("internal/source does not parse statements, only expressions")
-
 	fakeT := &fakeTestingT{}
 	assert := New(fakeT)
 
@@ -204,8 +202,15 @@ func TestTesterEqualFailureTypes(t *testing.T) {
 	expectFailNowed(t, fakeT, `assertion failed: 3 (int) != 3 (string)`)
 }
 
-func expectFailNowed(t *testing.T, fakeT *fakeTestingT, expected string) {
-	t.Helper()
+type testingT interface {
+	Errorf(msg string, args ...interface{})
+	Fatalf(msg string, args ...interface{})
+}
+
+func expectFailNowed(t testingT, fakeT *fakeTestingT, expected string) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
 	if fakeT.failed {
 		t.Errorf("should not have failed, got messages %s", fakeT.msgs)
 	}
@@ -217,8 +222,11 @@ func expectFailNowed(t *testing.T, fakeT *fakeTestingT, expected string) {
 	}
 }
 
-func expectFailed(t *testing.T, fakeT *fakeTestingT, expected string) {
-	t.Helper()
+// nolint: unparam
+func expectFailed(t testingT, fakeT *fakeTestingT, expected string) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
 	if fakeT.failNowed {
 		t.Errorf("should not have failNowed, got messages %s", fakeT.msgs)
 	}
@@ -230,8 +238,10 @@ func expectFailed(t *testing.T, fakeT *fakeTestingT, expected string) {
 	}
 }
 
-func expectSuccess(t *testing.T, fakeT *fakeTestingT) {
-	t.Helper()
+func expectSuccess(t testingT, fakeT *fakeTestingT) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
 	if fakeT.failNowed {
 		t.Errorf("should not have failNowed, got messages %s", fakeT.msgs)
 	}

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -97,8 +97,8 @@ func TestTesterAssertWithComparisonAndExtraMessage(t *testing.T) {
 	assert := New(fakeT)
 
 	cmp := exampleComparison{message: "oops, not good"}
-	assert.Assert(cmp, "extra stuff")
-	expectFailNowed(t, fakeT, "assertion failed: oops, not good: extra stuff")
+	assert.Assert(cmp, "extra stuff %v", true)
+	expectFailNowed(t, fakeT, "assertion failed: oops, not good: extra stuff true")
 }
 
 func TestAssertWithBoolFailure(t *testing.T) {

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -1,0 +1,241 @@
+package assert
+
+import (
+	"fmt"
+	"testing"
+)
+
+type fakeTestingT struct {
+	failNowed bool
+	failed    bool
+	msgs      []string
+}
+
+func (f *fakeTestingT) FailNow() {
+	f.failNowed = true
+}
+
+func (f *fakeTestingT) Fail() {
+	f.failed = true
+}
+
+func (f *fakeTestingT) Log(args ...interface{}) {
+	f.msgs = append(f.msgs, args[0].(string))
+}
+
+func (f *fakeTestingT) Helper() {}
+
+func TestTesterAssertWithBoolFailure(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	assert.Assert(1 > 5)
+	expectFailNowed(t, fakeT, "assertion failed: 1 > 5")
+}
+
+func TestTesterAssertWithBoolFailureAndExtraMessage(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	assert.Assert(1 > 5, "sometimes things fail")
+	expectFailNowed(t, fakeT, "assertion failed: 1 > 5: sometimes things fail")
+}
+
+func TestTesterAssertWithBoolSuccess(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	assert.Assert(1 < 5)
+	expectSuccess(t, fakeT)
+}
+
+func TestTesterAssertWithBoolMultiLineFailure(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	assert.Assert(func() bool {
+		for range []int{1, 2, 3, 4} {
+		}
+		return false
+	}())
+	expectFailNowed(t, fakeT, `assertion failed: func() bool {
+	for range []int{1, 2, 3, 4} {
+	}
+	return false
+}()`)
+}
+
+type exampleComparison struct {
+	success bool
+	message string
+}
+
+func (c exampleComparison) Compare() (bool, string) {
+	return c.success, c.message
+}
+
+func TestTesterAssertWithComparisonSuccess(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	cmp := exampleComparison{success: true}
+	assert.Assert(cmp)
+	expectSuccess(t, fakeT)
+}
+
+func TestTesterAssertWithComparisonFailure(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	cmp := exampleComparison{message: "oops, not good"}
+	assert.Assert(cmp)
+	expectFailNowed(t, fakeT, "assertion failed: oops, not good")
+}
+
+func TestTesterAssertWithComparisonAndExtraMessage(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	cmp := exampleComparison{message: "oops, not good"}
+	assert.Assert(cmp, "extra stuff")
+	expectFailNowed(t, fakeT, "assertion failed: oops, not good: extra stuff")
+}
+
+func TestAssertWithBoolFailure(t *testing.T) {
+	fakeT := &fakeTestingT{}
+
+	Assert(fakeT, 1 == 6)
+	expectFailNowed(t, fakeT, "assertion failed: 1 == 6")
+}
+
+type customError struct{}
+
+func (e *customError) Error() string {
+	return "custom error"
+}
+
+func TestTesterNoErrorSuccess(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	var err error
+	assert.NoError(err)
+	expectSuccess(t, fakeT)
+
+	assert.NoError(nil)
+	expectSuccess(t, fakeT)
+
+	var customErr *customError
+	assert.NoError(customErr)
+}
+
+func TestTesterNoErrorBadArg(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	assert.NoError(3, 4, 5)
+	expectFailNowed(t, fakeT, "assertion failed: last argument to NoError() must be an error, got int")
+}
+
+func TestTesterNoErrorFailure(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	assert.NoError(fmt.Errorf("this is the error"))
+	expectFailNowed(t, fakeT, "assertion failed: expected no error, got this is the error")
+}
+
+func TestTesterNoErrorWithMultiArgFailure(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	assert.NoError(func() (bool, int, error) {
+		return true, 3, fmt.Errorf("this is the error")
+	}())
+	expectFailNowed(t, fakeT, "assertion failed: expected no error, got this is the error")
+}
+
+func TestTesterCheckFailure(t *testing.T) {
+	t.Skip("internal/source does not parse statements, only expressions")
+
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	if assert.Check(1 == 2) {
+		t.Error("expected check to return false on failure")
+	}
+	expectFailed(t, fakeT, "assertion failed: 1 == 2")
+}
+
+func TestTesterCheckSuccess(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	if !assert.Check(1 == 1) {
+		t.Error("expected check to return true on success")
+	}
+	expectSuccess(t, fakeT)
+}
+
+func TestTesterEqualSuccess(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	assert.Equal(1, 1)
+	expectSuccess(t, fakeT)
+
+	assert.Equal("abcd", "abcd")
+	expectSuccess(t, fakeT)
+}
+
+func TestTesterEqualFailure(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	assert.Equal(1, 3)
+	expectFailNowed(t, fakeT, "assertion failed: 1 (int) != 3 (int)")
+}
+
+func TestTesterEqualFailureTypes(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	assert := New(fakeT)
+
+	assert.Equal(3, "3")
+	expectFailNowed(t, fakeT, `assertion failed: 3 (int) != 3 (string)`)
+}
+
+func expectFailNowed(t *testing.T, fakeT *fakeTestingT, expected string) {
+	t.Helper()
+	if fakeT.failed {
+		t.Errorf("should not have failed, got messages %s", fakeT.msgs)
+	}
+	if !fakeT.failNowed {
+		t.Fatalf("should have failNowed with message %s", expected)
+	}
+	if fakeT.msgs[0] != expected {
+		t.Fatalf("should have failure message %q, got %q", expected, fakeT.msgs[0])
+	}
+}
+
+func expectFailed(t *testing.T, fakeT *fakeTestingT, expected string) {
+	t.Helper()
+	if fakeT.failNowed {
+		t.Errorf("should not have failNowed, got messages %s", fakeT.msgs)
+	}
+	if !fakeT.failed {
+		t.Fatalf("should have failed with message %s", expected)
+	}
+	if fakeT.msgs[0] != expected {
+		t.Fatalf("should have failure message %q, got %q", expected, fakeT.msgs[0])
+	}
+}
+
+func expectSuccess(t *testing.T, fakeT *fakeTestingT) {
+	t.Helper()
+	if fakeT.failNowed {
+		t.Errorf("should not have failNowed, got messages %s", fakeT.msgs)
+	}
+	if fakeT.failed {
+		t.Errorf("should not have failed, got messages %s", fakeT.msgs)
+	}
+}

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -30,7 +30,8 @@ func TestTesterAssertWithBoolFailure(t *testing.T) {
 	assert := New(fakeT)
 
 	assert.Assert(1 > 5)
-	expectFailNowed(t, fakeT, "assertion failed: 1 > 5")
+	expectFailNowed(t, fakeT, "assertion failed: 1 > 5 is false")
+
 }
 
 func TestTesterAssertWithBoolFailureAndExtraMessage(t *testing.T) {
@@ -38,7 +39,7 @@ func TestTesterAssertWithBoolFailureAndExtraMessage(t *testing.T) {
 	assert := New(fakeT)
 
 	assert.Assert(1 > 5, "sometimes things fail")
-	expectFailNowed(t, fakeT, "assertion failed: 1 > 5: sometimes things fail")
+	expectFailNowed(t, fakeT, "assertion failed: 1 > 5 is false: sometimes things fail")
 }
 
 func TestTesterAssertWithBoolSuccess(t *testing.T) {
@@ -62,7 +63,7 @@ func TestTesterAssertWithBoolMultiLineFailure(t *testing.T) {
 	for range []int{1, 2, 3, 4} {
 	}
 	return false
-}()`)
+}() is false`)
 }
 
 type exampleComparison struct {
@@ -105,7 +106,7 @@ func TestAssertWithBoolFailure(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
 	Assert(fakeT, 1 == 6)
-	expectFailNowed(t, fakeT, "assertion failed: 1 == 6")
+	expectFailNowed(t, fakeT, "assertion failed: 1 == 6 is false")
 }
 
 type customError struct{}
@@ -162,7 +163,7 @@ func TestTesterCheckFailure(t *testing.T) {
 	if assert.Check(1 == 2) {
 		t.Error("expected check to return false on failure")
 	}
-	expectFailed(t, fakeT, "assertion failed: 1 == 2")
+	expectFailed(t, fakeT, "assertion failed: 1 == 2 is false")
 }
 
 func TestTesterCheckSuccess(t *testing.T) {

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -115,45 +115,45 @@ func (e *customError) Error() string {
 	return "custom error"
 }
 
-func TestTesterNoErrorSuccess(t *testing.T) {
+func TestTesterNilErrorSuccess(t *testing.T) {
 	fakeT := &fakeTestingT{}
 	assert := New(fakeT)
 
 	var err error
-	assert.NoError(err)
+	assert.NilError(err)
 	expectSuccess(t, fakeT)
 
-	assert.NoError(nil)
+	assert.NilError(nil)
 	expectSuccess(t, fakeT)
 
 	var customErr *customError
-	assert.NoError(customErr)
+	assert.NilError(customErr)
 }
 
-func TestTesterNoErrorBadArg(t *testing.T) {
+func TestTesterNilErrorBadArg(t *testing.T) {
 	fakeT := &fakeTestingT{}
 	assert := New(fakeT)
 
-	assert.NoError(3, 4, 5)
-	expectFailNowed(t, fakeT, "assertion failed: type int can not be nil")
+	assert.NilError(3, 4, 5)
+	expectFailNowed(t, fakeT, "assertion failed: 5 (type int) can not be nil")
 }
 
-func TestTesterNoErrorFailure(t *testing.T) {
+func TestTesterNilErrorFailure(t *testing.T) {
 	fakeT := &fakeTestingT{}
 	assert := New(fakeT)
 
-	assert.NoError(fmt.Errorf("this is the error"))
-	expectFailNowed(t, fakeT, "assertion failed: {this is the error} (*errors.errorString) is not nil")
+	assert.NilError(fmt.Errorf("this is the error"))
+	expectFailNowed(t, fakeT, "assertion failed: error is not nil: this is the error")
 }
 
-func TestTesterNoErrorWithMultiArgFailure(t *testing.T) {
+func TestTesterNilErrorWithMultiArgFailure(t *testing.T) {
 	fakeT := &fakeTestingT{}
 	assert := New(fakeT)
 
-	assert.NoError(func() (bool, int, error) {
+	assert.NilError(func() (bool, int, error) {
 		return true, 3, fmt.Errorf("this is the error")
 	}())
-	expectFailNowed(t, fakeT, "assertion failed: {this is the error} (*errors.errorString) is not nil")
+	expectFailNowed(t, fakeT, "assertion failed: error is not nil: this is the error")
 }
 
 func TestTesterCheckFailure(t *testing.T) {

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -80,7 +80,7 @@ func TestTesterAssertWithComparisonSuccess(t *testing.T) {
 	assert := New(fakeT)
 
 	cmp := exampleComparison{success: true}
-	assert.Assert(cmp)
+	assert.Assert(cmp.Compare)
 	expectSuccess(t, fakeT)
 }
 
@@ -89,7 +89,7 @@ func TestTesterAssertWithComparisonFailure(t *testing.T) {
 	assert := New(fakeT)
 
 	cmp := exampleComparison{message: "oops, not good"}
-	assert.Assert(cmp)
+	assert.Assert(cmp.Compare)
 	expectFailNowed(t, fakeT, "assertion failed: oops, not good")
 }
 
@@ -98,7 +98,7 @@ func TestTesterAssertWithComparisonAndExtraMessage(t *testing.T) {
 	assert := New(fakeT)
 
 	cmp := exampleComparison{message: "oops, not good"}
-	assert.Assert(cmp, "extra stuff %v", true)
+	assert.Assert(cmp.Compare, "extra stuff %v", true)
 	expectFailNowed(t, fakeT, "assertion failed: oops, not good: extra stuff true")
 }
 

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -135,7 +135,7 @@ func TestTesterNoErrorBadArg(t *testing.T) {
 	assert := New(fakeT)
 
 	assert.NoError(3, 4, 5)
-	expectFailNowed(t, fakeT, "assertion failed: last argument to NoError() must be an error, got int")
+	expectFailNowed(t, fakeT, "assertion failed: type int can not be nil")
 }
 
 func TestTesterNoErrorFailure(t *testing.T) {
@@ -143,7 +143,7 @@ func TestTesterNoErrorFailure(t *testing.T) {
 	assert := New(fakeT)
 
 	assert.NoError(fmt.Errorf("this is the error"))
-	expectFailNowed(t, fakeT, "assertion failed: expected no error, got this is the error")
+	expectFailNowed(t, fakeT, "assertion failed: {this is the error} (*errors.errorString) is not nil")
 }
 
 func TestTesterNoErrorWithMultiArgFailure(t *testing.T) {
@@ -153,7 +153,7 @@ func TestTesterNoErrorWithMultiArgFailure(t *testing.T) {
 	assert.NoError(func() (bool, int, error) {
 		return true, 3, fmt.Errorf("this is the error")
 	}())
-	expectFailNowed(t, fakeT, "assertion failed: expected no error, got this is the error")
+	expectFailNowed(t, fakeT, "assertion failed: {this is the error} (*errors.errorString) is not nil")
 }
 
 func TestTesterCheckFailure(t *testing.T) {

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -4,13 +4,14 @@ package cmp
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
 )
 
 // Compare two complex values using github.com/google/go-cmp/cmp and
 // succeeds if the values are equal
-func Compare(x, y interface{}, opts ...cmp.Option) func() (success bool, message string) {
+func Compare(x, y interface{}, opts ...cmp.Option) func() (bool, string) {
 	return func() (bool, string) {
 		diff := cmp.Diff(x, y, opts...)
 		// TODO: wrap error message?
@@ -26,7 +27,7 @@ func Equal(x, y interface{}) func() (success bool, message string) {
 }
 
 // Len succeeds if the sequence has the expected length
-func Len(seq interface{}, expected int) func() (success bool, message string) {
+func Len(seq interface{}, expected int) func() (bool, string) {
 	return func() (success bool, message string) {
 		defer func() {
 			if e := recover(); e != nil {
@@ -39,5 +40,88 @@ func Len(seq interface{}, expected int) func() (success bool, message string) {
 			return true, ""
 		}
 		return false, fmt.Sprintf("expected %s to have length %d", seq, expected)
+	}
+}
+
+// NoError succeeds if the last argument is a nil error
+func NoError(args ...interface{}) func() (bool, string) {
+	return func() (bool, string) {
+		if len(args) == 0 {
+			return true, ""
+		}
+		switch lastArg := args[len(args)-1].(type) {
+		case error:
+			return false, fmt.Sprintf("expected no error, got %s", lastArg)
+		case nil:
+			return true, ""
+		default:
+			return false, fmt.Sprintf(
+				"last argument to NoError() must be an error, got %T", lastArg)
+		}
+	}
+}
+
+// TODO: test
+func Zero(arg interface{}) func() (bool, string) {
+	return func() (bool, string) {
+		zero := reflect.Zero(reflect.TypeOf(arg))
+		value := reflect.ValueOf(arg)
+		return zero == value, fmt.Sprintf("%v is not zero", arg)
+	}
+}
+
+// TODO: test
+func NotZero(arg interface{}) func() (bool, string) {
+	return func() (bool, string) {
+		zero := reflect.Zero(reflect.TypeOf(arg))
+		value := reflect.ValueOf(arg)
+		return zero != value, fmt.Sprintf("%v is zero", arg)
+	}
+}
+
+// TODO: test
+// TODO: use == before DeepEqual, check for nils, like ObjectsAreEqual
+// TODO: document that reflect.DeepEqual is used
+func Contains(seq interface{}, item interface{}) func() (bool, string) {
+	return func() (bool, string) {
+		list := reflect.ValueOf(seq)
+		itemValue := reflect.ValueOf(item)
+		msg := fmt.Sprintf("%v does not contains %v", seq, item)
+
+		switch list.Type().Kind() {
+		case reflect.String:
+			success := strings.Contains(list.String(), itemValue.String())
+			return success, msg
+		case reflect.Map:
+			mapKeys := list.MapKeys()
+			for i := 0; i < len(mapKeys); i++ {
+				if reflect.DeepEqual(mapKeys[i].Interface(), itemValue) {
+					return true, ""
+				}
+			}
+			return false, msg
+		case reflect.Slice, reflect.Array, reflect.Chan:
+			for i := 0; i < list.Len(); i++ {
+				if reflect.DeepEqual(list.Index(i).Interface(), itemValue) {
+					return true, ""
+				}
+			}
+			return false, msg
+		default:
+			return false, fmt.Sprintf("type %T does not contain items", seq)
+		}
+	}
+}
+
+// TODO: test
+func Panics(f func()) func() (bool, string) {
+	return func() (success bool, message string) {
+		defer func() {
+			if err := recover(); err != nil {
+				success = true
+			}
+		}()
+		f()
+		return false, "did not panic"
 	}
 }

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -1,0 +1,43 @@
+/*Package cmp provides Comparisons for Assert and Check*/
+package cmp
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// Compare two complex values using github.com/google/go-cmp/cmp and
+// succeeds if the values are equal
+func Compare(x, y interface{}, opts ...cmp.Option) func() (success bool, message string) {
+	return func() (bool, string) {
+		diff := cmp.Diff(x, y, opts...)
+		// TODO: wrap error message?
+		return diff == "", diff
+	}
+}
+
+// Equal compares two values using the == operator
+func Equal(x, y interface{}) func() (success bool, message string) {
+	return func() (bool, string) {
+		return x == y, fmt.Sprintf("%v (%T) != %v (%T)", x, x, y, y)
+	}
+}
+
+// Len succeeds if the sequence has the expected length
+func Len(seq interface{}, expected int) func() (success bool, message string) {
+	return func() (success bool, message string) {
+		defer func() {
+			if e := recover(); e != nil {
+				success = false
+				message = fmt.Sprintf("type %T does not have a length", seq)
+			}
+		}()
+		value := reflect.ValueOf(seq)
+		if value.Len() == expected {
+			return true, ""
+		}
+		return false, fmt.Sprintf("expected %s to have length %d", seq, expected)
+	}
+}

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 )
 
-// Compare two complex values using github.com/google/go-cmp/cmp and
-// succeeds if the values are equal
+// Compare two complex values using https://godoc.org/github.com/google/go-cmp/cmp
+// and succeeds if the values are equal.
 func Compare(x, y interface{}, opts ...cmp.Option) func() (bool, string) {
 	return func() (bool, string) {
 		diff := cmp.Diff(x, y, opts...)

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -163,3 +163,25 @@ func ErrorContains(err error, substring string) func() (bool, string) {
 		return true, ""
 	}
 }
+
+// Nil succeeds if obj is a nil interface, pointer, or function.
+//
+// Use NoError() for comparing errors. Use Len(obj, 0) for comparing slices,
+// maps, and channels.
+func Nil(obj interface{}) func() (bool, string) {
+	return func() (bool, string) {
+		if obj == nil {
+			return true, ""
+		}
+		value := reflect.ValueOf(obj)
+		kind := value.Type().Kind()
+		if kind >= reflect.Chan && kind <= reflect.Slice {
+			if value.IsNil() {
+				return true, ""
+			}
+			return false, fmt.Sprintf("%v (%T) is not nil", reflect.Indirect(value), obj)
+		}
+
+		return false, fmt.Sprintf("type %T can not be nil", obj)
+	}
+}

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -16,7 +16,7 @@ func Compare(x, y interface{}, opts ...cmp.Option) func() (bool, string) {
 	return func() (bool, string) {
 		diff := cmp.Diff(x, y, opts...)
 		// TODO: wrap error message?
-		return diff == "", diff
+		return diff == "", "\n" + diff
 	}
 }
 
@@ -48,17 +48,9 @@ func Len(seq interface{}, expected int) func() (bool, string) {
 func NoError(args ...interface{}) func() (bool, string) {
 	return func() (bool, string) {
 		if len(args) == 0 {
-			return true, ""
+			return false, "NoError() requires one or more arguments"
 		}
-		switch lastArg := args[len(args)-1].(type) {
-		case error:
-			return false, fmt.Sprintf("expected no error, got %+v", lastArg)
-		case nil:
-			return true, ""
-		default:
-			return false, fmt.Sprintf(
-				"last argument to NoError() must be an error, got %T", lastArg)
-		}
+		return Nil(args[len(args)-1])()
 	}
 }
 

--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -1,0 +1,59 @@
+package cmp
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestLen(t *testing.T) {
+	var testcases = []struct {
+		seq             interface{}
+		length          int
+		expectedSuccess bool
+		expectedMessage string
+	}{
+		{
+			seq:             []string{"A", "b", "c"},
+			length:          3,
+			expectedSuccess: true,
+		},
+		{
+			seq:             []string{"A", "b", "c"},
+			length:          2,
+			expectedMessage: "expected [A b c] to have length 2",
+		},
+		{
+			seq:             map[string]int{"a": 1, "b": 2},
+			length:          2,
+			expectedSuccess: true,
+		},
+		{
+			seq:             [3]string{"a", "b", "c"},
+			length:          3,
+			expectedSuccess: true,
+		},
+		{
+			seq:             "abcd",
+			length:          4,
+			expectedSuccess: true,
+		},
+		{
+			seq:             "abcd",
+			length:          3,
+			expectedMessage: "expected abcd to have length 3",
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(fmt.Sprintf("%v len=%d", testcase.seq, testcase.length), func(t *testing.T) {
+			success, message := Len(testcase.seq, testcase.length)()
+			if success != testcase.expectedSuccess {
+				t.Errorf("expected success %v, got %v", testcase.expectedSuccess, success)
+			}
+
+			if message != testcase.expectedMessage {
+				t.Errorf("expected message %q, got %q", testcase.expectedMessage, message)
+			}
+		})
+	}
+}

--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -2,7 +2,10 @@ package cmp
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestLen(t *testing.T) {
@@ -47,13 +50,199 @@ func TestLen(t *testing.T) {
 	for _, testcase := range testcases {
 		t.Run(fmt.Sprintf("%v len=%d", testcase.seq, testcase.length), func(t *testing.T) {
 			success, message := Len(testcase.seq, testcase.length)()
-			if success != testcase.expectedSuccess {
-				t.Errorf("expected success %v, got %v", testcase.expectedSuccess, success)
-			}
-
-			if message != testcase.expectedMessage {
-				t.Errorf("expected message %q, got %q", testcase.expectedMessage, message)
+			if testcase.expectedSuccess {
+				assertSuccess(t, success, message)
+			} else {
+				assertFailure(t, success, message, testcase.expectedMessage)
 			}
 		})
+	}
+}
+
+func TestPanics(t *testing.T) {
+	panicker := func() {
+		panic("AHHHHHHHHHHH")
+	}
+
+	success, message := Panics(panicker)()
+	assertSuccess(t, success, message)
+
+	success, message = Panics(func() {})()
+	assertFailure(t, success, message, "did not panic")
+}
+
+type innerstub struct {
+	num int
+}
+
+type stub struct {
+	stub innerstub
+	num  int
+}
+
+func TestDeepEqual(t *testing.T) {
+	var testcases = []struct {
+		left     interface{}
+		right    interface{}
+		expected bool
+	}{
+		{nil, nil, true},
+		{7, 7, true},
+		{false, false, true},
+		{stub{innerstub{1}, 2}, stub{innerstub{1}, 2}, true},
+		{[]int{1, 2, 3}, []int{1, 2, 3}, true},
+		{[]byte(nil), []byte(nil), true},
+		{nil, []byte(nil), false},
+		{1, uint64(1), false},
+		{7, "7", false},
+	}
+	for _, testcase := range testcases {
+		if reflect.DeepEqual(testcase.left, testcase.right) != testcase.expected {
+			t.Errorf("deepEqual(%v, %v) did not return %v",
+				testcase.left, testcase.right, testcase.expected)
+		}
+	}
+}
+
+func TestContains(t *testing.T) {
+	var testcases = []struct {
+		seq         interface{}
+		item        interface{}
+		expected    bool
+		expectedMsg string
+	}{
+		{
+			seq:         error(nil),
+			item:        0,
+			expectedMsg: "nil does not contain items",
+		},
+		{
+			seq:      "abcdef",
+			item:     "cde",
+			expected: true,
+		},
+		{
+			seq:         "abcdef",
+			item:        "foo",
+			expectedMsg: "abcdef does not contain foo",
+		},
+		{
+			seq:      map[rune]int{'a': 1, 'b': 2},
+			item:     'b',
+			expected: true,
+		},
+		{
+			seq:         map[rune]int{'a': 1},
+			item:        'c',
+			expectedMsg: "map[97:1] does not contain 99",
+		},
+		{
+			seq:      []interface{}{"a", 1, 'a', 1.0, true},
+			item:     'a',
+			expected: true,
+		},
+		{
+			seq:         []interface{}{"a", 1, 'a', 1.0, true},
+			item:        3,
+			expectedMsg: "[a 1 97 1 true] does not contain 3",
+		},
+		{
+			seq:      [3]byte{99, 10, 100},
+			item:     byte(99),
+			expected: true,
+		},
+		{
+			seq:         [3]byte{99, 10, 100},
+			item:        byte(98),
+			expectedMsg: "[99 10 100] does not contain 98",
+		},
+	}
+	for _, testcase := range testcases {
+		success, message := Contains(testcase.seq, testcase.item)()
+		if testcase.expected {
+			assertSuccess(t, success, message)
+		} else {
+			assertFailure(t, success, message, testcase.expectedMsg)
+		}
+	}
+}
+
+func TestEqualMultiLine(t *testing.T) {
+	left := `abcd
+1234
+aaaa
+bbbb`
+
+	right := `abcd
+1111
+aaaa
+bbbb`
+
+	expected := `--- left
++++ right
+@@ -1,4 +1,4 @@
+ abcd
+-1234
++1111
+ aaaa
+ bbbb
+`
+
+	success, msg := EqualMultiLine(left, right)()
+	assertFailure(t, success, msg, expected)
+}
+
+func TestError(t *testing.T) {
+	success, message := Error(nil, "the error message")()
+	assertFailure(t, success, message, "expected an error, got nil")
+
+	success, message = Error(errors.New("other"), "the error message")()
+	assertFailure(t, success, message,
+		`expected error message "the error message", got "other"`)
+
+	msg := "the message"
+	success, message = Error(errors.New(msg), msg)()
+	assertSuccess(t, success, message)
+}
+
+func TestErrorContains(t *testing.T) {
+	success, message := ErrorContains(nil, "the error message")()
+	assertFailure(t, success, message, "expected an error, got nil")
+
+	success, message = ErrorContains(errors.New("other"), "the error")()
+	assertFailure(t, success, message,
+		`expected error message to contain "the error", got "other"`)
+
+	msg := "the full message"
+	success, message = ErrorContains(errors.New(msg), "full")()
+	assertSuccess(t, success, message)
+}
+
+type testingT interface {
+	Errorf(msg string, args ...interface{})
+}
+
+type helperT interface {
+	Helper()
+}
+
+func assertSuccess(t testingT, success bool, message string) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	if !success {
+		t.Errorf("expected success, but got failure with message %q", message)
+	}
+}
+
+func assertFailure(t testingT, success bool, message string, expected string) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	if success {
+		t.Errorf("expected failure")
+	}
+	if message != expected {
+		t.Errorf("expected \n%q\ngot\n%q\n", expected, message)
 	}
 }

--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -2,6 +2,7 @@ package cmp
 
 import (
 	"fmt"
+	"io"
 	"reflect"
 	"testing"
 
@@ -216,6 +217,29 @@ func TestErrorContains(t *testing.T) {
 	msg := "the full message"
 	success, message = ErrorContains(errors.New(msg), "full")()
 	assertSuccess(t, success, message)
+}
+
+func TestNil(t *testing.T) {
+	success, message := Nil(nil)()
+	assertSuccess(t, success, message)
+
+	var s *string
+	success, message = Nil(s)()
+	assertSuccess(t, success, message)
+
+	var closer io.Closer
+	success, message = Nil(closer)()
+	assertSuccess(t, success, message)
+
+	success, message = Nil("wrong")()
+	assertFailure(t, success, message, "type string can not be nil")
+
+	notnil := "notnil"
+	success, message = Nil(&notnil)()
+	assertFailure(t, success, message, "notnil (*string) is not nil")
+
+	success, message = Nil([]string{"a"})()
+	assertFailure(t, success, message, "[a] ([]string) is not nil")
 }
 
 type testingT interface {

--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -143,7 +143,12 @@ func TestContains(t *testing.T) {
 		{
 			seq:         "abcdef",
 			item:        "foo",
-			expectedMsg: "abcdef does not contain foo",
+			expectedMsg: `string "abcdef" does not contain "foo"`,
+		},
+		{
+			seq:         "abcdef",
+			item:        3,
+			expectedMsg: `string may only contain strings`,
 		},
 		{
 			seq:      map[rune]int{'a': 1, 'b': 2},
@@ -154,6 +159,11 @@ func TestContains(t *testing.T) {
 			seq:         map[rune]int{'a': 1},
 			item:        'c',
 			expectedMsg: "map[97:1] does not contain 99",
+		},
+		{
+			seq:         map[int]int{'a': 1, 'b': 2},
+			item:        'b',
+			expectedMsg: "map[int]int can not contain a int32 key",
 		},
 		{
 			seq:      []interface{}{"a", 1, 'a', 1.0, true},
@@ -177,12 +187,15 @@ func TestContains(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		success, message := Contains(testcase.seq, testcase.item)()
-		if testcase.expected {
-			assertSuccess(t, success, message)
-		} else {
-			assertFailure(t, success, message, testcase.expectedMsg)
-		}
+		name := fmt.Sprintf("%v in %v", testcase.item, testcase.seq)
+		t.Run(name, func(t *testing.T) {
+			success, message := Contains(testcase.seq, testcase.item)()
+			if testcase.expected {
+				assertSuccess(t, success, message)
+			} else {
+				assertFailure(t, success, message, testcase.expectedMsg)
+			}
+		})
 	}
 }
 

--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -60,6 +60,24 @@ func TestLen(t *testing.T) {
 	}
 }
 
+type stubError struct{}
+
+func (e *stubError) Error() string { return "stub error" }
+
+func TestNoError(t *testing.T) {
+	var s *stubError
+
+	success, message := NoError(s)()
+	assertSuccess(t, success, message)
+
+	success, message = NoError(nil)()
+	assertSuccess(t, success, message)
+
+	var e error
+	success, message = NoError(e)()
+	assertSuccess(t, success, message)
+}
+
 func TestPanics(t *testing.T) {
 	panicker := func() {
 		panic("AHHHHHHHHHHH")

--- a/env/env.go
+++ b/env/env.go
@@ -7,37 +7,39 @@ import (
 	"os"
 	"strings"
 
-	"github.com/stretchr/testify/require"
+	"github.com/gotestyourself/gotestyourself/assert"
 )
 
 // Patch changes the value of an environment variable, and returns a
 // function which will reset the the value of that variable back to the
 // previous state.
-func Patch(t require.TestingT, key, value string) func() {
+func Patch(t assert.TestingT, key, value string) func() {
+	assert := assert.New(t)
 	oldValue, ok := os.LookupEnv(key)
-	require.NoError(t, os.Setenv(key, value))
+	assert.NoError(os.Setenv(key, value))
 	return func() {
 		if !ok {
-			require.NoError(t, os.Unsetenv(key))
+			assert.NoError(os.Unsetenv(key))
 			return
 		}
-		require.NoError(t, os.Setenv(key, oldValue))
+		assert.NoError(os.Setenv(key, oldValue))
 	}
 }
 
 // PatchAll sets the environment to env, and returns a function which will
 // reset the environment back to the previous state.
-func PatchAll(t require.TestingT, env map[string]string) func() {
+func PatchAll(t assert.TestingT, env map[string]string) func() {
+	assert := assert.New(t)
 	oldEnv := os.Environ()
 	os.Clearenv()
 
 	for key, value := range env {
-		require.NoError(t, os.Setenv(key, value))
+		assert.NoError(os.Setenv(key, value))
 	}
 	return func() {
 		os.Clearenv()
 		for key, oldVal := range ToMap(oldEnv) {
-			require.NoError(t, os.Setenv(key, oldVal))
+			assert.NoError(os.Setenv(key, oldVal))
 		}
 	}
 }

--- a/env/env.go
+++ b/env/env.go
@@ -62,11 +62,11 @@ func ToMap(env []string) map[string]string {
 
 // ChangeWorkingDir to the directory, and return a function which restores the
 // previous working directory.
-func ChangeWorkingDir(t require.TestingT, dir string) func() {
+func ChangeWorkingDir(t assert.TestingT, dir string) func() {
 	cwd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
+	assert.NilError(t, err)
+	assert.NilError(t, os.Chdir(dir))
 	return func() {
-		require.NoError(t, os.Chdir(cwd))
+		assert.NilError(t, os.Chdir(cwd))
 	}
 }

--- a/env/env.go
+++ b/env/env.go
@@ -16,13 +16,13 @@ import (
 func Patch(t assert.TestingT, key, value string) func() {
 	assert := assert.New(t)
 	oldValue, ok := os.LookupEnv(key)
-	assert.NoError(os.Setenv(key, value))
+	assert.NilError(os.Setenv(key, value))
 	return func() {
 		if !ok {
-			assert.NoError(os.Unsetenv(key))
+			assert.NilError(os.Unsetenv(key))
 			return
 		}
-		assert.NoError(os.Setenv(key, oldValue))
+		assert.NilError(os.Setenv(key, oldValue))
 	}
 }
 
@@ -34,12 +34,12 @@ func PatchAll(t assert.TestingT, env map[string]string) func() {
 	os.Clearenv()
 
 	for key, value := range env {
-		assert.NoError(os.Setenv(key, value))
+		assert.NilError(os.Setenv(key, value))
 	}
 	return func() {
 		os.Clearenv()
 		for key, oldVal := range ToMap(oldEnv) {
-			assert.NoError(os.Setenv(key, oldVal))
+			assert.NilError(os.Setenv(key, oldVal))
 		}
 	}
 }

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -6,30 +6,31 @@ import (
 
 	"sort"
 
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/skip"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPatchFromUnset(t *testing.T) {
 	key, value := "FOO_IS_UNSET", "VALUE"
 	revert := Patch(t, key, value)
 
-	assert.Equal(t, value, os.Getenv(key))
+	assert.Assert(t, value == os.Getenv(key))
 	revert()
 	_, isSet := os.LookupEnv(key)
-	assert.False(t, isSet)
+	assert.Assert(t, isSet == false)
 }
 
 func TestPatch(t *testing.T) {
-	skip.IfCondition(t, os.Getenv("PATH") == "")
+	skip.If(t, os.Getenv("PATH") == "")
 	oldVal := os.Getenv("PATH")
 
 	key, value := "PATH", "NEWVALUE"
 	revert := Patch(t, key, value)
 
-	assert.Equal(t, value, os.Getenv(key))
+	assert.Assert(t, value == os.Getenv(key))
 	revert()
-	assert.Equal(t, oldVal, os.Getenv(key))
+	assert.Assert(t, oldVal == os.Getenv(key))
 }
 
 func TestPatchAll(t *testing.T) {
@@ -43,10 +44,10 @@ func TestPatchAll(t *testing.T) {
 
 	actual := os.Environ()
 	sort.Strings(actual)
-	assert.Equal(t, []string{"FIRST=STARS", "THEN=MOON"}, actual)
+	assert.Assert(t, cmp.Compare([]string{"FIRST=STARS", "THEN=MOON"}, actual))
 
 	revert()
-	assert.Equal(t, sorted(oldEnv), sorted(os.Environ()))
+	assert.Assert(t, cmp.Compare(sorted(oldEnv), sorted(os.Environ())))
 }
 
 func sorted(source []string) []string {
@@ -58,5 +59,5 @@ func TestToMap(t *testing.T) {
 	source := []string{"key=value", "novaluekey"}
 	actual := ToMap(source)
 	expected := map[string]string{"key": "value", "novaluekey": ""}
-	assert.Equal(t, expected, actual)
+	assert.Assert(t, cmp.Compare(expected, actual))
 }

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -18,7 +18,7 @@ func TestPatchFromUnset(t *testing.T) {
 	assert.Assert(t, value == os.Getenv(key))
 	revert()
 	_, isSet := os.LookupEnv(key)
-	assert.Assert(t, isSet == false)
+	assert.Assert(t, !isSet)
 }
 
 func TestPatch(t *testing.T) {

--- a/fs/example_test.go
+++ b/fs/example_test.go
@@ -3,18 +3,14 @@ package fs_test
 import (
 	"io/ioutil"
 	"os"
+	"testing"
 
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/fs"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-type fakeTesting struct{}
-
-func (t fakeTesting) Errorf(format string, args ...interface{}) {}
-func (t fakeTesting) FailNow()                                  {}
-
-var t = fakeTesting{}
+var t = &testing.T{}
 
 // Create a temporary directory which contains a single file
 func ExampleNewDir() {
@@ -22,8 +18,8 @@ func ExampleNewDir() {
 	defer dir.Remove()
 
 	files, err := ioutil.ReadDir(dir.Path())
-	require.NoError(t, err)
-	assert.Len(t, files, 0)
+	assert.NoError(t, err)
+	assert.Assert(t, cmp.Len(files, 0))
 }
 
 // Create a new file with some content
@@ -32,7 +28,7 @@ func ExampleNewFile() {
 	defer file.Remove()
 
 	content, err := ioutil.ReadFile(file.Path())
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "content\n", content)
 }
 

--- a/fs/example_test.go
+++ b/fs/example_test.go
@@ -18,7 +18,7 @@ func ExampleNewDir() {
 	defer dir.Remove()
 
 	files, err := ioutil.ReadDir(dir.Path())
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	assert.Assert(t, cmp.Len(files, 0))
 }
 
@@ -28,7 +28,7 @@ func ExampleNewFile() {
 	defer file.Remove()
 
 	content, err := ioutil.ReadFile(file.Path())
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	assert.Equal(t, "content\n", content)
 }
 

--- a/fs/file.go
+++ b/fs/file.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/stretchr/testify/require"
+	"github.com/gotestyourself/gotestyourself/assert"
 )
 
 // Path objects return their filesystem path. Both File and Dir implement Path.
@@ -23,14 +23,14 @@ type File struct {
 
 // NewFile creates a new file in a temporary directory using prefix as part of
 // the filename. The PathOps are applied to the before returning the File.
-func NewFile(t require.TestingT, prefix string, ops ...PathOp) *File {
+func NewFile(t assert.TestingT, prefix string, ops ...PathOp) *File {
 	tempfile, err := ioutil.TempFile("", prefix+"-")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	file := &File{path: tempfile.Name()}
-	require.NoError(t, tempfile.Close())
+	assert.NoError(t, tempfile.Close())
 
 	for _, op := range ops {
-		require.NoError(t, op(file))
+		assert.NoError(t, op(file))
 	}
 	return file
 }
@@ -53,13 +53,13 @@ type Dir struct {
 
 // NewDir returns a new temporary directory using prefix as part of the directory
 // name. The PathOps are applied before returning the Dir.
-func NewDir(t require.TestingT, prefix string, ops ...PathOp) *Dir {
+func NewDir(t assert.TestingT, prefix string, ops ...PathOp) *Dir {
 	path, err := ioutil.TempDir("", prefix+"-")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	dir := &Dir{path: path}
 
 	for _, op := range ops {
-		require.NoError(t, op(dir))
+		assert.NoError(t, op(dir))
 	}
 	return dir
 }

--- a/fs/file.go
+++ b/fs/file.go
@@ -25,12 +25,12 @@ type File struct {
 // the filename. The PathOps are applied to the before returning the File.
 func NewFile(t assert.TestingT, prefix string, ops ...PathOp) *File {
 	tempfile, err := ioutil.TempFile("", prefix+"-")
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	file := &File{path: tempfile.Name()}
-	assert.NoError(t, tempfile.Close())
+	assert.NilError(t, tempfile.Close())
 
 	for _, op := range ops {
-		assert.NoError(t, op(file))
+		assert.NilError(t, op(file))
 	}
 	return file
 }
@@ -55,11 +55,11 @@ type Dir struct {
 // name. The PathOps are applied before returning the Dir.
 func NewDir(t assert.TestingT, prefix string, ops ...PathOp) *Dir {
 	path, err := ioutil.TempDir("", prefix+"-")
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	dir := &Dir{path: path}
 
 	for _, op := range ops {
-		assert.NoError(t, op(dir))
+		assert.NilError(t, op(dir))
 	}
 	return dir
 }

--- a/fs/ops_test.go
+++ b/fs/ops_test.go
@@ -4,8 +4,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/gotestyourself/gotestyourself/assert"
 )
 
 func TestFromDir(t *testing.T) {
@@ -20,7 +19,7 @@ func TestFromDir(t *testing.T) {
 
 func assertFileWithContent(t *testing.T, path, content string) {
 	actual, err := ioutil.ReadFile(path)
-	require.NoError(t, err, "file %s does not exist", path)
+	assert.NoError(t, err)
 
-	assert.Equal(t, content, string(actual), "file %s")
+	assert.Equal(t, content, string(actual), "file %s", path)
 }

--- a/fs/ops_test.go
+++ b/fs/ops_test.go
@@ -19,7 +19,7 @@ func TestFromDir(t *testing.T) {
 
 func assertFileWithContent(t *testing.T, path, content string) {
 	actual, err := ioutil.ReadFile(path)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 
 	assert.Equal(t, content, string(actual), "file %s", path)
 }

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -29,7 +29,7 @@ func Get(t assert.TestingT, filename string) []byte {
 		ht.Helper()
 	}
 	expected, err := ioutil.ReadFile(Path(filename))
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	return expected
 }
 
@@ -44,7 +44,7 @@ func Path(filename string) string {
 func update(t assert.TestingT, filename string, actual []byte) {
 	if *flagUpdate {
 		err := ioutil.WriteFile(Path(filename), actual, 0644)
-		assert.NoError(t, err)
+		assert.NilError(t, err)
 	}
 }
 
@@ -70,7 +70,7 @@ func Assert(t assert.TestingT, actual string, filename string, msgAndArgs ...int
 		ToFile:   "Actual",
 		Context:  3,
 	})
-	assert.Assert(t, cmp.NoError(err), msgAndArgs...)
+	assert.Assert(t, cmp.NilError(err), msgAndArgs...)
 	t.Log(format.WithCustomMessage(fmt.Sprintf("Not Equal: \n%s", diff), msgAndArgs...))
 	t.Fail()
 	return false

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -15,8 +15,6 @@ type fakeT struct {
 	Failed bool
 }
 
-func (t *fakeT) Helper() {}
-
 func (t *fakeT) Log(...interface{}) {
 }
 

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -6,27 +6,25 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/fs"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type fakeT struct {
 	Failed bool
 }
 
-func (t *fakeT) Fatal(_ ...interface{}) {
-	t.Failed = true
-}
+func (t *fakeT) Helper() {}
 
-func (t *fakeT) Fatalf(string, ...interface{}) {
-	t.Failed = true
-}
-
-func (t *fakeT) Errorf(_ string, _ ...interface{}) {
+func (t *fakeT) Log(...interface{}) {
 }
 
 func (t *fakeT) FailNow() {
+	t.Failed = true
+}
+
+func (t *fakeT) Fail() {
 	t.Failed = true
 }
 
@@ -34,7 +32,7 @@ func TestGoldenGetInvalidFile(t *testing.T) {
 	fakeT := new(fakeT)
 
 	Get(fakeT, "/invalid/path")
-	require.True(t, fakeT.Failed)
+	assert.Assert(t, fakeT.Failed)
 }
 
 func TestGoldenGetAbsolutePath(t *testing.T) {
@@ -43,7 +41,7 @@ func TestGoldenGetAbsolutePath(t *testing.T) {
 	fakeT := new(fakeT)
 
 	Get(fakeT, file.Path())
-	require.False(t, fakeT.Failed)
+	assert.Assert(t, !fakeT.Failed)
 }
 
 func TestGoldenGet(t *testing.T) {
@@ -55,8 +53,8 @@ func TestGoldenGet(t *testing.T) {
 	fakeT := new(fakeT)
 
 	actual := Get(fakeT, filename)
-	assert.False(t, fakeT.Failed)
-	assert.Equal(t, actual, []byte(expected))
+	assert.Assert(t, !fakeT.Failed)
+	assert.Assert(t, cmp.Compare(actual, []byte(expected)))
 }
 
 func TestGoldenAssertInvalidContent(t *testing.T) {
@@ -66,8 +64,8 @@ func TestGoldenAssertInvalidContent(t *testing.T) {
 	fakeT := new(fakeT)
 
 	success := Assert(fakeT, "foo", filename)
-	assert.False(t, fakeT.Failed)
-	assert.False(t, success)
+	assert.Assert(t, fakeT.Failed)
+	assert.Assert(t, !success)
 }
 
 func TestGoldenAssertInvalidContentUpdate(t *testing.T) {
@@ -79,8 +77,8 @@ func TestGoldenAssertInvalidContentUpdate(t *testing.T) {
 	fakeT := new(fakeT)
 
 	success := Assert(fakeT, "foo", filename)
-	assert.False(t, fakeT.Failed)
-	assert.True(t, success)
+	assert.Assert(t, !fakeT.Failed)
+	assert.Assert(t, success)
 }
 
 func TestGoldenAssert(t *testing.T) {
@@ -90,8 +88,8 @@ func TestGoldenAssert(t *testing.T) {
 	fakeT := new(fakeT)
 
 	success := Assert(fakeT, "foo", filename)
-	assert.False(t, fakeT.Failed)
-	assert.True(t, success)
+	assert.Assert(t, !fakeT.Failed)
+	assert.Assert(t, success)
 }
 
 func TestGoldenAssertBytes(t *testing.T) {
@@ -101,8 +99,8 @@ func TestGoldenAssertBytes(t *testing.T) {
 	fakeT := new(fakeT)
 
 	success := AssertBytes(fakeT, []byte("foo"), filename)
-	assert.False(t, fakeT.Failed)
-	assert.True(t, success)
+	assert.Assert(t, !fakeT.Failed)
+	assert.Assert(t, success)
 }
 
 func setUpdateFlag() func() {
@@ -114,12 +112,12 @@ func setUpdateFlag() func() {
 func setupGoldenFile(t *testing.T, content string) (string, func()) {
 	_ = os.Mkdir("testdata", 0755)
 	f, err := ioutil.TempFile("testdata", "")
-	require.NoError(t, err, "fail to setup test golden file")
+	assert.Assert(t, cmp.NoError(err), "fail to setup test golden file")
 	err = ioutil.WriteFile(f.Name(), []byte(content), 0660)
-	require.NoError(t, err, "fail to write test golden file with %q", content)
+	assert.Assert(t, cmp.NoError(err), "fail to write test golden file with %q", content)
 	_, name := filepath.Split(f.Name())
 	t.Log(f.Name(), name)
 	return name, func() {
-		require.NoError(t, os.Remove(f.Name()))
+		assert.NoError(t, os.Remove(f.Name()))
 	}
 }

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -110,12 +110,12 @@ func setUpdateFlag() func() {
 func setupGoldenFile(t *testing.T, content string) (string, func()) {
 	_ = os.Mkdir("testdata", 0755)
 	f, err := ioutil.TempFile("testdata", "")
-	assert.Assert(t, cmp.NoError(err), "fail to setup test golden file")
+	assert.Assert(t, cmp.NilError(err), "fail to setup test golden file")
 	err = ioutil.WriteFile(f.Name(), []byte(content), 0660)
-	assert.Assert(t, cmp.NoError(err), "fail to write test golden file with %q", content)
+	assert.Assert(t, cmp.NilError(err), "fail to write test golden file with %q", content)
 	_, name := filepath.Split(f.Name())
 	t.Log(f.Name(), name)
 	return name, func() {
-		assert.NoError(t, os.Remove(f.Name()))
+		assert.NilError(t, os.Remove(f.Name()))
 	}
 }

--- a/icmd/command.go
+++ b/icmd/command.go
@@ -14,6 +14,9 @@ import (
 
 type testingT interface {
 	Fatalf(string, ...interface{})
+}
+
+type helperT interface {
 	Helper()
 }
 
@@ -52,7 +55,9 @@ type Result struct {
 // any of the expectations are not met.
 // TODO: deprecate and replace with assert.CompareFunc
 func (r *Result) Assert(t testingT, exp Expected) *Result {
-	t.Helper()
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
 	err := r.Compare(exp)
 	if err == nil {
 		return r

--- a/icmd/command.go
+++ b/icmd/command.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -16,10 +14,11 @@ import (
 
 type testingT interface {
 	Fatalf(string, ...interface{})
+	Helper()
 }
 
 // None is a token to inform Result.Assert that the output should be empty
-const None string = "[NOTHING]"
+const None = "[NOTHING]"
 
 type lockedBuffer struct {
 	m   sync.RWMutex
@@ -51,17 +50,14 @@ type Result struct {
 
 // Assert compares the Result against the Expected struct, and fails the test if
 // any of the expectations are not met.
+// TODO: deprecate and replace with assert.CompareFunc
 func (r *Result) Assert(t testingT, exp Expected) *Result {
+	t.Helper()
 	err := r.Compare(exp)
 	if err == nil {
 		return r
 	}
-	_, file, line, ok := runtime.Caller(1)
-	if ok {
-		t.Fatalf("at %s:%d - %s\n", filepath.Base(file), line, err.Error())
-	} else {
-		t.Fatalf("(no file/line info) - %s", err.Error())
-	}
+	t.Fatalf(err.Error() + "\n")
 	return nil
 }
 

--- a/icmd/command_test.go
+++ b/icmd/command_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
 )
 
 func TestRunCommandSuccess(t *testing.T) {
-	// TODO Windows: Port this test
 	if runtime.GOOS == "windows" {
 		t.Skip("Needs porting to Windows")
 	}
@@ -20,7 +20,6 @@ func TestRunCommandSuccess(t *testing.T) {
 }
 
 func TestRunCommandWithCombined(t *testing.T) {
-	// TODO Windows: Port this test
 	if runtime.GOOS == "windows" {
 		t.Skip("Needs porting to Windows")
 	}
@@ -28,12 +27,11 @@ func TestRunCommandWithCombined(t *testing.T) {
 	result := RunCommand("ls", "-a")
 	result.Assert(t, Expected{})
 
-	assert.Contains(t, result.Combined(), "..")
-	assert.Contains(t, result.Stdout(), "..")
+	assert.Assert(t, cmp.Contains(result.Combined(), "\n..\n"))
+	assert.Assert(t, cmp.Contains(result.Stdout(), "\n..\n"))
 }
 
 func TestRunCommandWithTimeoutFinished(t *testing.T) {
-	// TODO Windows: Port this test
 	if runtime.GOOS == "windows" {
 		t.Skip("Needs porting to Windows")
 	}
@@ -46,7 +44,6 @@ func TestRunCommandWithTimeoutFinished(t *testing.T) {
 }
 
 func TestRunCommandWithTimeoutKilled(t *testing.T) {
-	// TODO Windows: Port this test
 	if runtime.GOOS == "windows" {
 		t.Skip("Needs porting to Windows")
 	}
@@ -56,7 +53,7 @@ func TestRunCommandWithTimeoutKilled(t *testing.T) {
 	result.Assert(t, Expected{Timeout: true})
 
 	ones := strings.Split(result.Stdout(), "\n")
-	assert.Len(t, ones, 4)
+	assert.Assert(t, cmp.Len(ones, 4))
 }
 
 func TestRunCommandWithErrors(t *testing.T) {

--- a/icmd/example_test.go
+++ b/icmd/example_test.go
@@ -1,12 +1,12 @@
 package icmd_test
 
-import "github.com/gotestyourself/gotestyourself/icmd"
+import (
+	"testing"
 
-type fakeTesting struct{}
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
 
-func (t fakeTesting) Fatalf(string, ...interface{}) {}
-
-var t = fakeTesting{}
+var t = &testing.T{}
 
 func ExampleRunCommand() {
 	result := icmd.RunCommand("bash", "-c", "echo all good")

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -1,0 +1,27 @@
+package format
+
+import "fmt"
+
+// Message accepts a msgAndArgs varargs and formats it using fmt.Sprintf
+func Message(msgAndArgs ...interface{}) string {
+	switch len(msgAndArgs) {
+	case 0:
+		return ""
+	case 1:
+		return msgAndArgs[0].(string)
+	default:
+		return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
+	}
+}
+
+// WithCustomMessage accepts one or two messages and formats them appropriately
+func WithCustomMessage(source string, msgAndArgs ...interface{}) string {
+	custom := Message(msgAndArgs...)
+	switch {
+	case custom == "":
+		return source
+	case source == "":
+		return custom
+	}
+	return fmt.Sprintf("%s: %s", source, custom)
+}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -8,7 +8,7 @@ func Message(msgAndArgs ...interface{}) string {
 	case 0:
 		return ""
 	case 1:
-		return msgAndArgs[0].(string)
+		return fmt.Sprintf("%v", msgAndArgs[0])
 	default:
 		return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
 	}

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -1,15 +1,18 @@
-package source
+package source_test
+
+// using a separate package for test to avoid circular imports with the assert
+// package
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/internal/source"
 )
 
 func TestGetConditionSingleLine(t *testing.T) {
 	msg, err := shim("not", "this", "this text")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, `"this text"`, msg)
 }
 
@@ -19,7 +22,7 @@ func TestGetConditionMultiLine(t *testing.T) {
 		"second",
 		"this text",
 	)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, `"this text"`, msg)
 }
 
@@ -29,11 +32,11 @@ func TestGetConditionIfStatement(t *testing.T) {
 		"second",
 		"this text",
 	); true {
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, `"this text"`, msg)
 	}
 }
 
 func shim(_, _, _ string) (string, error) {
-	return GetCondition(1, 2)
+	return source.GetCondition(1, 2)
 }

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGetConditionSingleLine(t *testing.T) {
 	msg, err := shim("not", "this", "this text")
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	assert.Equal(t, `"this text"`, msg)
 }
 
@@ -22,7 +22,7 @@ func TestGetConditionMultiLine(t *testing.T) {
 		"second",
 		"this text",
 	)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	assert.Equal(t, `"this text"`, msg)
 }
 
@@ -32,7 +32,7 @@ func TestGetConditionIfStatement(t *testing.T) {
 		"second",
 		"this text",
 	); true {
-		assert.NoError(t, err)
+		assert.NilError(t, err)
 		assert.Equal(t, `"this text"`, msg)
 	}
 }

--- a/poll/poll_test.go
+++ b/poll/poll_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 )
 
 type fakeT struct {
@@ -44,9 +45,9 @@ func TestWaitOnWithTimeout(t *testing.T) {
 		return Continue("not done")
 	}
 
-	assert.Panics(t, func() {
+	assert.Assert(t, cmp.Panics(func() {
 		WaitOn(fakeT, check, WithTimeout(time.Millisecond))
-	})
+	}))
 	assert.Equal(t, "timeout hit after 1ms: not done", fakeT.failed)
 }
 
@@ -58,7 +59,7 @@ func TestWaitOnWithCheckTimeout(t *testing.T) {
 		return Continue("not done")
 	}
 
-	assert.Panics(t, func() { WaitOn(fakeT, check, WithTimeout(time.Millisecond)) })
+	assert.Assert(t, cmp.Panics(func() { WaitOn(fakeT, check, WithTimeout(time.Millisecond)) }))
 	assert.Equal(t, "timeout hit after 1ms: first check never completed", fakeT.failed)
 }
 
@@ -69,6 +70,6 @@ func TestWaitOnWithCheckError(t *testing.T) {
 		return Error(errors.New("broke"))
 	}
 
-	assert.Panics(t, func() { WaitOn(fakeT, check) })
+	assert.Assert(t, cmp.Panics(func() { WaitOn(fakeT, check) }))
 	assert.Equal(t, "polling check failed: broke", fakeT.failed)
 }

--- a/skip/skip.go
+++ b/skip/skip.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/gotestyourself/gotestyourself/internal/format"
 	"github.com/gotestyourself/gotestyourself/internal/source"
 )
 
@@ -29,9 +30,7 @@ func If(t skipT, condition BoolOrCheckFunc, msgAndArgs ...interface{}) {
 		ifCondition(t, check, msgAndArgs...)
 	case func() bool:
 		if check() {
-			t.Skip(formatWithCustomMessage(
-				getFunctionName(check),
-				formatMessage(msgAndArgs...)))
+			t.Skip(format.WithCustomMessage(getFunctionName(check), msgAndArgs...))
 		}
 	default:
 		panic(fmt.Sprintf("invalid type for condition arg: %T", check))
@@ -63,28 +62,7 @@ func ifCondition(t skipT, condition bool, msgAndArgs ...interface{}) {
 	source, err := source.GetCondition(stackIndex, argPos)
 	if err != nil {
 		t.Log(err.Error())
-		t.Skip(formatMessage(msgAndArgs...))
+		t.Skip(format.Message(msgAndArgs...))
 	}
-	t.Skip(formatWithCustomMessage(source, formatMessage(msgAndArgs...)))
-}
-
-func formatMessage(msgAndArgs ...interface{}) string {
-	switch len(msgAndArgs) {
-	case 0:
-		return ""
-	case 1:
-		return msgAndArgs[0].(string)
-	default:
-		return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
-	}
-}
-
-func formatWithCustomMessage(source, custom string) string {
-	switch {
-	case custom == "":
-		return source
-	case source == "":
-		return custom
-	}
-	return fmt.Sprintf("%s: %s", source, custom)
+	t.Skip(format.WithCustomMessage(source, msgAndArgs...))
 }

--- a/skip/skip_test.go
+++ b/skip/skip_test.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
 )
 
 type fakeSkipT struct {
@@ -35,7 +36,7 @@ func TestIfCondition(t *testing.T) {
 	If(skipT, apiVersion < version("v1.6"))
 
 	assert.Equal(t, `apiVersion < version("v1.6")`, skipT.reason)
-	assert.Len(t, skipT.logs, 0)
+	assert.Assert(t, cmp.Len(skipT.logs, 0))
 }
 
 func TestIfConditionWithMessage(t *testing.T) {
@@ -44,7 +45,7 @@ func TestIfConditionWithMessage(t *testing.T) {
 	If(skipT, apiVersion < "v1.6", "see notes")
 
 	assert.Equal(t, `apiVersion < "v1.6": see notes`, skipT.reason)
-	assert.Len(t, skipT.logs, 0)
+	assert.Assert(t, cmp.Len(skipT.logs, 0))
 }
 
 func TestIfConditionMultiline(t *testing.T) {
@@ -55,7 +56,7 @@ func TestIfConditionMultiline(t *testing.T) {
 		apiVersion < "v1.6")
 
 	assert.Equal(t, `apiVersion < "v1.6"`, skipT.reason)
-	assert.Len(t, skipT.logs, 0)
+	assert.Assert(t, cmp.Len(skipT.logs, 0))
 }
 
 func TestIfConditionMultilineWithMessage(t *testing.T) {
@@ -67,7 +68,7 @@ func TestIfConditionMultilineWithMessage(t *testing.T) {
 		"see notes")
 
 	assert.Equal(t, `apiVersion < "v1.6": see notes`, skipT.reason)
-	assert.Len(t, skipT.logs, 0)
+	assert.Assert(t, cmp.Len(skipT.logs, 0))
 }
 
 func TestIfConditionNoSkip(t *testing.T) {
@@ -75,7 +76,7 @@ func TestIfConditionNoSkip(t *testing.T) {
 	If(skipT, false)
 
 	assert.Equal(t, "", skipT.reason)
-	assert.Len(t, skipT.logs, 0)
+	assert.Assert(t, cmp.Len(skipT.logs, 0))
 }
 
 func SkipBecauseISaidSo() bool {

--- a/testsum/scan_test.go
+++ b/testsum/scan_test.go
@@ -45,7 +45,7 @@ ok      github.com/gotestyourself/gotestyourself/icmd   1.256s
 
 	out := new(bytes.Buffer)
 	summary, err := Scan(strings.NewReader(source), out)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	assert.Check(t, summary.Elapsed != 0)
 	assert.Check(t, compare(&Summary{Total: 8, Skipped: 1}, summary))
 	assert.Equal(t, source, out.String())
@@ -70,7 +70,7 @@ FAIL    github.com/gotestyourself/gotestyourself/testsum        0.002s
 
 	out := new(bytes.Buffer)
 	summary, err := Scan(strings.NewReader(source), out)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	assert.Check(t, summary.Elapsed != 0)
 	assert.Check(t, cmp.Equal(source, out.String()))
 
@@ -103,7 +103,7 @@ PASS
 `
 
 	summary, err := Scan(strings.NewReader(source), ioutil.Discard)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	assert.Check(t, summary.Elapsed != 0)
 
 	expected := &Summary{Total: 1}
@@ -130,7 +130,7 @@ exit status 1
 `
 
 	summary, err := Scan(strings.NewReader(source), ioutil.Discard)
-	assert.NoError(t, err)
+	assert.NilError(t, err)
 	assert.Check(t, summary.Elapsed != 0)
 
 	expectedOutput := `=== RUN   TestNested/a


### PR DESCRIPTION
Closes #26
Fixes #20

Adds a new `assert` package, addressing the issues discussed in #26, as well as type safety. `assert` is designed to support custom `Comparison`s, which allow users to write type safe ones for specific types. Includes some general purpose comparisons for the most common cases.
