### PR TITLE
Add gty-migrate-from-testify binary

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -15,3 +15,6 @@
   name = "github.com/google/go-cmp"
   version = "0.2.0"
 
+[[constraint]]
+  branch = "master"
+  name = "golang.org/x/tools"

--- a/assert/cmd/gty-migrate-from-testify/call.go
+++ b/assert/cmd/gty-migrate-from-testify/call.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/token"
+)
+
+// call wraps an testify assert ast.CallExpr and exposes properties of the
+// expression to facilitate migrating the expression to a gotestyourself assert
+type call struct {
+	fileset *token.FileSet
+	expr    *ast.CallExpr
+	xIdent  *ast.Ident
+	selExpr *ast.SelectorExpr
+	assert  string
+}
+
+func (c call) String() string {
+	args := new(bytes.Buffer)
+	format.Node(args, token.NewFileSet(), c.expr)
+	return args.String()
+}
+
+func (c call) StringWithFileInfo() string {
+	if c.fileset.File(c.expr.Pos()) == nil {
+		return fmt.Sprintf("%s at unknown file", c)
+	}
+	return fmt.Sprintf("%s at %s:%d", c,
+		relativePath(c.fileset.File(c.expr.Pos()).Name()),
+		c.fileset.Position(c.expr.Pos()).Line)
+}
+
+// testingT returns the first argument of the call, which is assumed to be a
+// *ast.Ident of *testing.T or a compatible interface.
+func (c call) testingT() ast.Expr {
+	if len(c.expr.Args) == 0 {
+		return nil
+	}
+	return c.expr.Args[0]
+}
+
+// extraArgs returns the arguments of the expression starting from index
+func (c call) extraArgs(index int) []ast.Expr {
+	if len(c.expr.Args) <= index {
+		return nil
+	}
+	return c.expr.Args[index:]
+}
+
+// args returns a range of arguments from the expression
+func (c call) args(from, to int) []ast.Expr {
+	return c.expr.Args[from:to]
+}
+
+// arg returns a single argument from the expression
+func (c call) arg(index int) ast.Expr {
+	return c.expr.Args[index]
+}
+
+// newCallFromCallExpr returns a new call build from a ast.CallExpr. Returns false
+// if the call expression does not have the expected ast nodes.
+func newCallFromCallExpr(callExpr *ast.CallExpr, migration migration) (call, bool) {
+	c := call{}
+	selector, ok := callExpr.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return c, false
+	}
+	ident, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return c, false
+	}
+
+	return call{
+		fileset: migration.fileset,
+		xIdent:  ident,
+		selExpr: selector,
+		expr:    callExpr,
+	}, true
+}
+
+// newTestifyCallFromNode returns a call that wraps a valid testify assertion.
+// Returns false if the call expression is not a testify assertion.
+func newTestifyCallFromNode(callExpr *ast.CallExpr, migration migration) (call, bool) {
+	tcall, ok := newCallFromCallExpr(callExpr, migration)
+	if !ok {
+		return tcall, false
+	}
+
+	testifyNewAssignStmt := testifyAssertionsAssignment(tcall, migration)
+	switch {
+	case testifyNewAssignStmt != nil:
+		return updateCallForTestifyNew(tcall, testifyNewAssignStmt, migration)
+	case isTestifyPkgCall(tcall, migration):
+		tcall.assert = migration.importNames.funcNameFromTestifyName(tcall.xIdent.Name)
+		return tcall, true
+	}
+	return tcall, false
+}
+
+// isTestifyPkgCall returns true if the call is a testify package-level assertion
+// (as apposed to an assertion method on the Assertions type)
+//
+// TODO: check if the xIdent.Obj.Decl is an import declaration instead of
+// assuming that a name matching the import name is always an import. Some code
+// may shadow import names, which could lead to incorrect results.
+func isTestifyPkgCall(tcall call, migration migration) bool {
+	return migration.importNames.matchesTestify(tcall.xIdent)
+}
+
+// testifyAssertionsAssignment returns an ast.AssignStmt if the call is a testify
+// call from an Assertions object returned from assert.New(t) (not a package level
+// assert). Otherwise returns nil.
+func testifyAssertionsAssignment(tcall call, migration migration) *ast.AssignStmt {
+	if tcall.xIdent.Obj == nil {
+		return nil
+	}
+
+	assignStmt, ok := tcall.xIdent.Obj.Decl.(*ast.AssignStmt)
+	if !ok {
+		return nil
+	}
+
+	if isAssignmentFromAssertNew(assignStmt, migration) {
+		return assignStmt
+	}
+	return nil
+}
+
+func updateCallForTestifyNew(
+	tcall call,
+	testifyNewAssignStmt *ast.AssignStmt,
+	migration migration,
+) (call, bool) {
+	testifyNewCallExpr := callExprFromAssignment(testifyNewAssignStmt)
+	if testifyNewCallExpr == nil {
+		return tcall, false
+	}
+	testifyNewCall, ok := newCallFromCallExpr(testifyNewCallExpr, migration)
+	if !ok {
+		return tcall, false
+	}
+
+	tcall.assert = migration.importNames.funcNameFromTestifyName(testifyNewCall.xIdent.Name)
+	tcall.expr = addMissingTestingTArgToCallExpr(tcall.expr, testifyNewCall.testingT())
+	return tcall, true
+}
+
+// addMissingTestingTArgToCallExpr adds a testingT arg as the first arg of the
+// ast.CallExpr and returns a copy of the ast.CallExpr
+func addMissingTestingTArgToCallExpr(callExpr *ast.CallExpr, testingT ast.Expr) *ast.CallExpr {
+	return &ast.CallExpr{
+		Fun:  callExpr.Fun,
+		Args: append([]ast.Expr{removePos(testingT)}, callExpr.Args...),
+	}
+}
+
+func removePos(node ast.Expr) ast.Expr {
+	switch typed := node.(type) {
+	case *ast.Ident:
+		return &ast.Ident{Name: typed.Name}
+	}
+	return node
+}
+
+// TODO: use pkgInfo and walkForType instead?
+func isAssignmentFromAssertNew(assign *ast.AssignStmt, migration migration) bool {
+	callExpr := callExprFromAssignment(assign)
+	if callExpr == nil {
+		return false
+	}
+	tcall, ok := newCallFromCallExpr(callExpr, migration)
+	if !ok {
+		return false
+	}
+	if !migration.importNames.matchesTestify(tcall.xIdent) {
+		return false
+	}
+
+	if len(tcall.expr.Args) != 1 {
+		return false
+	}
+	return tcall.selExpr.Sel.Name == "New"
+}
+
+func callExprFromAssignment(assign *ast.AssignStmt) *ast.CallExpr {
+	if len(assign.Rhs) != 1 {
+		return nil
+	}
+
+	callExpr, ok := assign.Rhs[0].(*ast.CallExpr)
+	if !ok {
+		return nil
+	}
+	return callExpr
+}

--- a/assert/cmd/gty-migrate-from-testify/doc.go
+++ b/assert/cmd/gty-migrate-from-testify/doc.go
@@ -1,0 +1,18 @@
+/*
+
+Command gty-migration-from-testify migrates one or more packages from
+testify/assert and testify/require to gotestyourself/assert.
+
+To run on all packages (including external test packages) use:
+
+	go list \
+		-f '{{.ImportPath}} {{if .XTestGoFiles}}{{"\n"}}{{.ImportPath}}_test{{end}}' \
+		./... | xargs gty-migrate-from-testify
+
+The cmp package can be aliases to make the assertions more readable:
+
+    gty-migrate-from-testify --import-cmp-alias=is
+
+*/
+
+package main

--- a/assert/cmd/gty-migrate-from-testify/importer.go
+++ b/assert/cmd/gty-migrate-from-testify/importer.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"go/build"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	pkgGocheck      = "github.com/go-check/check"
+	pkgGopkgGocheck = "gopkg.in/check.v1"
+)
+
+var allTestingTPkgs = append(
+	allTestifyPks,
+	pkgGocheck,
+	pkgGopkgGocheck,
+)
+
+func newFakeImporter() (*fakeImporter, error) {
+	tmpDir, err := ioutil.TempDir("", "gty-migrate-from-testify")
+	err = errors.Wrapf(err, "failed to create temporary directory")
+	return &fakeImporter{tmpDir: tmpDir}, err
+}
+
+type fakeImporter struct {
+	tmpDir string
+}
+
+func (f *fakeImporter) Cleanup() error {
+	return os.RemoveAll(f.tmpDir)
+}
+
+func (f *fakeImporter) Import(
+	ctx *build.Context,
+	path string,
+	dir string,
+	mode build.ImportMode,
+) (*build.Package, error) {
+	pkg, err := ctx.Import(path, dir, mode)
+	if err == nil {
+		return pkg, err
+	}
+
+	for _, pkgName := range allTestingTPkgs {
+		if pkgName == path {
+			return importStubPackage(f.tmpDir, pkgName)
+		}
+	}
+
+	return pkg, err
+}
+
+func importStubPackage(tmpDir string, importPath string) (*build.Package, error) {
+	pkgName := strings.TrimSuffix(path.Base(importPath), ".v1")
+	pkgFilePath := filepath.Join(tmpDir, pkgName)
+
+	if err := os.MkdirAll(pkgFilePath, 0755); err != nil {
+		return nil, errors.Wrapf(err, "failed to create stub package directory")
+	}
+
+	const filename = "fixture.go"
+	if err := writeStubFile(filepath.Join(pkgFilePath, filename), pkgName); err != nil {
+		return nil, errors.Wrapf(err, "failed to write stub file")
+	}
+
+	return &build.Package{
+		Dir:        pkgFilePath,
+		Name:       pkgName,
+		ImportPath: importPath,
+		GoFiles:    []string{filename},
+	}, nil
+}
+
+func writeStubFile(path string, pkgName string) error {
+	content := []byte(fmt.Sprintf(stubFixtureContent, pkgName))
+	return ioutil.WriteFile(path, content, 0644)
+}
+
+const stubFixtureContent = `
+package %s
+
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+func New(t TestingT) *Assertions {
+	return &Assertions{}
+}
+
+type Assertions struct {}
+
+type C struct{}
+
+`

--- a/assert/cmd/gty-migrate-from-testify/main.go
+++ b/assert/cmd/gty-migrate-from-testify/main.go
@@ -198,11 +198,11 @@ func (p importNames) matchesTestify(ident *ast.Ident) bool {
 func (p importNames) funcNameFromTestifyName(name string) string {
 	switch name {
 	case p.testifyAssert:
-		return "Check"
+		return funcNameCheck
 	case p.testifyRequire:
-		return "Assert"
+		return funcNameAssert
 	default:
-		return ""
+		panic("unexpected testify import name " + name)
 	}
 }
 

--- a/assert/cmd/gty-migrate-from-testify/main.go
+++ b/assert/cmd/gty-migrate-from-testify/main.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"bytes"
+	"go/ast"
+	"go/build"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+	"golang.org/x/tools/go/loader"
+	"golang.org/x/tools/imports"
+)
+
+type options struct {
+	pkgs             []string
+	dryRun           bool
+	debug            bool
+	cmpImportName    string
+	showLoaderErrors bool
+	useAllFiles      bool
+}
+
+func main() {
+	name := os.Args[0]
+	flags, opts := setupFlags(name)
+	handleExitError(name, flags.Parse(os.Args[1:]))
+	setupLogging(opts)
+	opts.pkgs = flags.Args()
+	handleExitError(name, run(*opts))
+}
+
+func setupLogging(opts *options) {
+	log.SetFlags(0)
+	enableDebug = opts.debug
+}
+
+var enableDebug = false
+
+func debugf(msg string, args ...interface{}) {
+	if enableDebug {
+		log.Printf("DEBUG: "+msg, args...)
+	}
+}
+
+func setupFlags(name string) (*pflag.FlagSet, *options) {
+	opts := options{}
+	flags := pflag.NewFlagSet(name, pflag.ContinueOnError)
+	flags.BoolVar(&opts.dryRun, "dry-run", false, "don't write to file")
+	flags.BoolVar(&opts.debug, "debug", false, "enable debug logging")
+	flags.StringVar(&opts.cmpImportName, "import-cmp-alias", "is",
+		"import alias to use for the assert/cmp package")
+	flags.BoolVar(&opts.showLoaderErrors, "print-loader-errors", false,
+		"print errors from loading source")
+	flags.BoolVar(&opts.useAllFiles, "ignore-build-tags", false,
+		"use files regardless of +build lines, file names")
+	// TODO: set usage func to print more usage
+	return flags, &opts
+}
+
+func handleExitError(name string, err error) {
+	switch {
+	case err == nil:
+		return
+	case err == pflag.ErrHelp:
+		os.Exit(0)
+	default:
+		log.Println(name + ": Error: " + err.Error())
+		os.Exit(3)
+	}
+}
+
+func run(opts options) error {
+	program, err := loadProgram(opts)
+	if err != nil {
+		return errors.Wrapf(err, "failed to load program")
+	}
+	pkgs := program.InitialPackages()
+	debugf("package count: %d", len(pkgs))
+
+	fileset := program.Fset
+	for _, pkg := range pkgs {
+		for _, astFile := range pkg.Files {
+			absFilename := fileset.File(astFile.Pos()).Name()
+			filename := relativePath(absFilename)
+			importNames := newImportNames(astFile.Imports, opts)
+			if !importNames.hasTestifyImports() {
+				debugf("skipping file %s, no imports", filename)
+				continue
+			}
+
+			debugf("migrating %s with imports: %#v", filename, importNames)
+			m := migration{
+				file:        astFile,
+				fileset:     fileset,
+				importNames: importNames,
+				pkgInfo:     pkg,
+			}
+			migrateFile(m)
+			if opts.dryRun {
+				continue
+			}
+
+			raw, err := formatFile(m)
+			if err != nil {
+				return errors.Wrapf(err, "failed to format %s", filename)
+			}
+
+			if err := ioutil.WriteFile(absFilename, raw, 0); err != nil {
+				return errors.Wrapf(err, "failed to write file %s", filename)
+			}
+		}
+	}
+
+	return nil
+}
+
+func loadProgram(opts options) (*loader.Program, error) {
+	conf := loader.Config{
+		Fset:        token.NewFileSet(),
+		ParserMode:  parser.ParseComments,
+		Build:       buildContext(opts),
+		AllowErrors: true,
+	}
+	for _, pkg := range opts.pkgs {
+		conf.ImportWithTests(pkg)
+	}
+	if !opts.showLoaderErrors {
+		conf.TypeChecker.Error = func(e error) {}
+	}
+	return conf.Load()
+}
+
+func buildContext(opts options) *build.Context {
+	c := build.Default
+	c.UseAllFiles = opts.useAllFiles
+	if val, ok := os.LookupEnv("GOPATH"); ok {
+		c.GOPATH = val
+	}
+	return &c
+}
+
+func relativePath(p string) string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return p
+	}
+	rel, err := filepath.Rel(cwd, p)
+	if err != nil {
+		return p
+	}
+	return rel
+}
+
+type importNames struct {
+	testifyAssert  string
+	testifyRequire string
+	assert         string
+	cmp            string
+}
+
+func (p importNames) hasTestifyImports() bool {
+	return p.testifyAssert != "" || p.testifyRequire != ""
+}
+
+func (p importNames) matchesTestify(ident *ast.Ident) bool {
+	return ident.Name == p.testifyAssert || ident.Name == p.testifyRequire
+}
+
+func (p importNames) funcNameFromTestifyName(name string) string {
+	switch name {
+	case p.testifyAssert:
+		return "Check"
+	case p.testifyRequire:
+		return "Assert"
+	default:
+		panic("unknown testify package name: " + name)
+	}
+}
+
+func newImportNames(imports []*ast.ImportSpec, opt options) importNames {
+	importNames := importNames{
+		assert: path.Base(pkgAssert),
+		cmp:    path.Base(pkgCmp),
+	}
+	for _, spec := range imports {
+		switch strings.Trim(spec.Path.Value, `"`) {
+		case pkgTestifyAssert, pkgGopkgTestifyAssert:
+			importNames.testifyAssert = identOrDefault(spec.Name, "assert")
+		case pkgTestifyRequire, pkgGopkgTestifyRequire:
+			importNames.testifyRequire = identOrDefault(spec.Name, "require")
+		default:
+			if importedAs(spec, path.Base(pkgAssert)) {
+				importNames.assert = "gtyassert"
+			}
+		}
+	}
+
+	if opt.cmpImportName != "" {
+		importNames.cmp = opt.cmpImportName
+	}
+	return importNames
+}
+
+func importedAs(spec *ast.ImportSpec, pkg string) bool {
+	if path.Base(strings.Trim(spec.Path.Value, `""`)) == pkg {
+		return true
+	}
+	return spec.Name != nil && spec.Name.Name == pkg
+}
+
+func identOrDefault(ident *ast.Ident, def string) string {
+	if ident != nil {
+		return ident.Name
+	}
+	return def
+}
+
+func formatFile(migration migration) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	err := format.Node(buf, migration.fileset, migration.file)
+	if err != nil {
+		return nil, err
+	}
+	filename := migration.fileset.File(migration.file.Pos()).Name()
+	return imports.Process(filename, buf.Bytes(), nil)
+}

--- a/assert/cmd/gty-migrate-from-testify/main_test.go
+++ b/assert/cmd/gty-migrate-from-testify/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/env"
+	"github.com/gotestyourself/gotestyourself/fs"
+	"github.com/gotestyourself/gotestyourself/golden"
+)
+
+func TestRun(t *testing.T) {
+	setupLogging(&options{})
+	dir := fs.NewDir(t, "test-run",
+		fs.WithDir("src/example.com/example", fs.FromDir("testdata/full")))
+	defer dir.Remove()
+
+	defer env.Patch(t, "GOPATH", dir.Path())()
+	err := run(options{
+		pkgs: []string{"example.com/example"},
+	})
+	assert.NilError(t, err)
+
+	raw, err := ioutil.ReadFile(dir.Join("src/example.com/example/some_test.go"))
+	assert.NilError(t, err)
+	golden.Assert(t, string(raw), "full-expected/some_test.go")
+}

--- a/assert/cmd/gty-migrate-from-testify/migrate.go
+++ b/assert/cmd/gty-migrate-from-testify/migrate.go
@@ -1,0 +1,379 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/token"
+	"go/types"
+	"log"
+	"path"
+
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/loader"
+)
+
+const (
+	pkgTestifyAssert       = "github.com/stretchr/testify/assert"
+	pkgGopkgTestifyAssert  = "gopkg.in/stretchr/testify.v1/assert"
+	pkgTestifyRequire      = "github.com/stretchr/testify/require"
+	pkgGopkgTestifyRequire = "gopkg.in/stretchr/testify.v1/require"
+	pkgAssert              = "github.com/gotestyourself/gotestyourself/assert"
+	pkgCmp                 = "github.com/gotestyourself/gotestyourself/assert/cmp"
+)
+
+type migration struct {
+	file        *ast.File
+	fileset     *token.FileSet
+	importNames importNames
+	pkgInfo     *loader.PackageInfo
+}
+
+func migrateFile(migration migration) {
+	astutil.Apply(migration.file, nil, replaceCalls(migration))
+	updateImports(migration)
+}
+
+func updateImports(migration migration) {
+	for _, remove := range []string{
+		pkgTestifyAssert,
+		pkgTestifyRequire,
+		pkgGopkgTestifyAssert,
+		pkgGopkgTestifyRequire,
+	} {
+		astutil.DeleteImport(migration.fileset, migration.file, remove)
+	}
+
+	var alias string
+	if migration.importNames.assert != path.Base(pkgAssert) {
+		alias = migration.importNames.assert
+	}
+	astutil.AddNamedImport(migration.fileset, migration.file, alias, pkgAssert)
+
+	if migration.importNames.cmp != path.Base(pkgCmp) {
+		alias = migration.importNames.cmp
+	}
+	astutil.AddNamedImport(migration.fileset, migration.file, alias, pkgCmp)
+}
+
+func replaceCalls(migration migration) func(cursor *astutil.Cursor) bool {
+	return func(cursor *astutil.Cursor) bool {
+		var newNode ast.Node
+		switch typed := cursor.Node().(type) {
+		case *ast.SelectorExpr:
+			newNode = getReplacementTestingT(typed, migration.importNames)
+		case *ast.CallExpr:
+			newNode = getReplacementAssertion(typed, migration)
+		}
+
+		if newNode != nil {
+			cursor.Replace(newNode)
+		}
+		return true
+	}
+}
+
+func getReplacementTestingT(selector *ast.SelectorExpr, names importNames) ast.Node {
+	xIdent, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return nil
+	}
+	if selector.Sel.Name != "TestingT" || !names.matchesTestify(xIdent) {
+		return nil
+	}
+	return &ast.SelectorExpr{
+		X:   &ast.Ident{Name: names.assert, NamePos: xIdent.NamePos},
+		Sel: selector.Sel,
+	}
+}
+
+func getReplacementAssertion(callExpr *ast.CallExpr, migration migration) ast.Node {
+	tcall, ok := newCallFromNode(callExpr, migration)
+	if !ok {
+		return nil
+	}
+	if !migration.importNames.matchesTestify(tcall.xIdent) {
+		return nil
+	}
+	if len(tcall.expr.Args) < 2 {
+		return convertTestifySingleArgCall(tcall, migration)
+	}
+	return convertTestifyAssertion(tcall, migration)
+}
+
+func newCallFromNode(callExpr *ast.CallExpr, migration migration) (call, bool) {
+	c := call{}
+	selector, ok := callExpr.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return c, false
+	}
+	ident, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return c, false
+	}
+	return call{
+		fileset: migration.fileset,
+		expr:    callExpr,
+		xIdent:  ident,
+		selExpr: selector,
+	}, true
+}
+
+type call struct {
+	fileset *token.FileSet
+	expr    *ast.CallExpr
+	xIdent  *ast.Ident
+	selExpr *ast.SelectorExpr
+}
+
+func (c call) String() string {
+	args := new(bytes.Buffer)
+	format.Node(args, token.NewFileSet(), c.expr)
+	return args.String()
+}
+
+func (c call) StringWithFileInfo() string {
+	if c.fileset.File(c.expr.Pos()) == nil {
+		return fmt.Sprintf("%s at unknown file", c)
+	}
+	return fmt.Sprintf("%s at %s:%d", c,
+		relativePath(c.fileset.File(c.expr.Pos()).Name()),
+		c.fileset.Position(c.expr.Pos()).Line)
+}
+
+func (c call) testingT() ast.Expr {
+	if len(c.expr.Args) == 0 {
+		return nil
+	}
+	return c.expr.Args[0]
+}
+
+func (c call) extraArgs(index int) []ast.Expr {
+	if len(c.expr.Args) <= index {
+		return nil
+	}
+	return c.expr.Args[index:]
+}
+
+func convertTestifySingleArgCall(tcall call, migration migration) ast.Node {
+	switch tcall.selExpr.Sel.Name {
+	case "TestingT":
+		// Already handled as SelectorExpr
+		return nil
+	case "New":
+		// TODO: assert.New() - astutil.Apply() -> get selector.X from lhs of assignment
+		log.Printf("%s: not yet implemented", tcall.StringWithFileInfo())
+		return nil
+	default:
+		log.Printf("%s: skipping unknown selector", tcall.StringWithFileInfo())
+		return nil
+	}
+}
+
+// nolint: gocyclo
+func convertTestifyAssertion(tcall call, migration migration) ast.Node {
+	imports := migration.importNames
+
+	switch tcall.selExpr.Sel.Name {
+	case "NoError", "NoErrorf":
+		return convertNoError(tcall, imports)
+	case "True", "Truef":
+		return convertTrue(tcall, imports)
+	case "False", "Falsef":
+		return convertFalse(tcall, imports)
+	case "Equal", "Equalf", "Exactly", "Exactlyf", "EqualValues", "EqualValuesf":
+		return convertEqual(tcall, migration)
+	case "Contains", "Containsf":
+		return convertTwoArgComparison(tcall, imports, "Contains")
+	case "Len", "Lenf":
+		return convertTwoArgComparison(tcall, imports, "Len")
+	case "Panics", "Panicsf":
+		return convertOneArgComparison(tcall, imports, "Panics")
+	case "EqualError", "EqualErrorf":
+		return convertTwoArgComparison(tcall, imports, "Error")
+	case "Error", "Errorf":
+		return convertError(tcall, imports)
+	case "Empty", "Emptyf":
+		return convertEmpty(tcall, imports)
+	case "Nil", "Nilf":
+		return convertNil(tcall, migration)
+	case "NotNil", "NotNilf":
+		return convertNegativeComparison(tcall, imports, &ast.Ident{Name: "nil"}, 2)
+	case "NotEqual", "NotEqualf":
+		return convertNegativeComparison(tcall, imports, tcall.expr.Args[2], 3)
+	case "Fail", "Failf":
+		return convertFail(tcall, "Error")
+	case "FailNow", "FailNowf":
+		return convertFail(tcall, "Fatal")
+	case "NotEmpty", "NotEmptyf":
+		return convertNotEmpty(tcall, imports)
+	}
+	log.Printf("%s: skipping unsupported assertion", tcall.StringWithFileInfo())
+	return nil
+}
+
+func newCallExpr(x, sel string, args []ast.Expr) *ast.CallExpr {
+	return &ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X:   &ast.Ident{Name: x},
+			Sel: &ast.Ident{Name: sel},
+		},
+		Args: args,
+	}
+}
+
+func newCallExprArgs(t ast.Expr, cmp ast.Expr, extra ...ast.Expr) []ast.Expr {
+	return append(append([]ast.Expr{t}, cmp), extra...)
+}
+
+func newCallExprWithPosition(tcall call, imports importNames, args []ast.Expr) *ast.CallExpr {
+	return &ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X: &ast.Ident{
+				Name:    imports.assert,
+				NamePos: tcall.xIdent.NamePos,
+			},
+			Sel: &ast.Ident{Name: imports.funcNameFromTestifyName(tcall.xIdent.Name)},
+		},
+		Args: args,
+	}
+}
+
+func convertNoError(tcall call, imports importNames) ast.Node {
+	// use assert.NoError() if there are no extra args
+	if len(tcall.expr.Args) == 2 && tcall.xIdent.Name == imports.testifyRequire {
+		return &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X: &ast.Ident{
+					Name:    imports.assert,
+					NamePos: tcall.xIdent.NamePos,
+				},
+				Sel: &ast.Ident{Name: "NilError"},
+			},
+			Args: tcall.expr.Args,
+		}
+	}
+	return convertOneArgComparison(tcall, imports, "NilError")
+}
+
+func convertOneArgComparison(tcall call, imports importNames, cmpName string) ast.Node {
+	return newCallExprWithPosition(tcall, imports,
+		newCallExprArgs(
+			tcall.testingT(),
+			newCallExpr(imports.cmp, cmpName, []ast.Expr{tcall.expr.Args[1]}),
+			tcall.extraArgs(2)...))
+}
+
+func convertTrue(tcall call, imports importNames) ast.Node {
+	return newCallExprWithPosition(tcall, imports, tcall.expr.Args)
+}
+
+func convertFalse(tcall call, imports importNames) ast.Node {
+	return newCallExprWithPosition(tcall, imports,
+		newCallExprArgs(
+			tcall.testingT(),
+			&ast.UnaryExpr{Op: token.NOT, X: tcall.expr.Args[1]},
+			tcall.extraArgs(2)...))
+}
+
+func convertEqual(tcall call, migration migration) ast.Node {
+	imports := migration.importNames
+
+	cmpEquals := convertTwoArgComparison(tcall, imports, "Equal")
+	cmpCompare := convertTwoArgComparison(tcall, imports, "Compare")
+
+	gotype := walkForType(migration.pkgInfo, tcall.expr.Args[1])
+	if isUnknownType(gotype) {
+		gotype = walkForType(migration.pkgInfo, tcall.expr.Args[2])
+	}
+	if isUnknownType(gotype) {
+		return cmpCompare
+	}
+
+	switch gotype.Underlying().(type) {
+	case *types.Basic:
+		return cmpEquals
+	default:
+		return cmpCompare
+	}
+}
+
+func convertTwoArgComparison(tcall call, imports importNames, cmpName string) ast.Node {
+	return newCallExprWithPosition(tcall, imports,
+		newCallExprArgs(
+			tcall.testingT(),
+			newCallExpr(imports.cmp, cmpName, tcall.expr.Args[1:3]),
+			tcall.extraArgs(3)...))
+}
+
+func convertError(tcall call, imports importNames) ast.Node {
+	return newCallExprWithPosition(tcall, imports,
+		newCallExprArgs(
+			tcall.testingT(),
+			newCallExpr(
+				imports.cmp,
+				"ErrorContains",
+				append(tcall.expr.Args[1:2], &ast.BasicLit{Kind: token.STRING, Value: `""`})),
+			tcall.extraArgs(2)...))
+}
+
+func convertEmpty(tcall call, imports importNames) ast.Node {
+	return newCallExprWithPosition(tcall, imports,
+		newCallExprArgs(
+			tcall.testingT(),
+			newCallExpr(
+				imports.cmp,
+				"Len",
+				append(tcall.expr.Args[1:2], &ast.BasicLit{Kind: token.INT, Value: "0"})),
+			tcall.extraArgs(2)...))
+}
+
+func convertNil(tcall call, migration migration) ast.Node {
+	gotype := walkForType(migration.pkgInfo, tcall.expr.Args[1])
+	if gotype != nil && gotype.String() == "error" {
+		return convertNoError(tcall, migration.importNames)
+	}
+	return convertOneArgComparison(tcall, migration.importNames, "Nil")
+}
+
+func convertNegativeComparison(
+	tcall call,
+	imports importNames,
+	right ast.Expr,
+	extra int,
+) ast.Node {
+	return newCallExprWithPosition(tcall, imports,
+		newCallExprArgs(
+			tcall.testingT(),
+			&ast.BinaryExpr{X: tcall.expr.Args[1], Op: token.NEQ, Y: right},
+			tcall.extraArgs(extra)...))
+}
+
+func convertFail(tcall call, selector string) ast.Node {
+	extraArgs := tcall.extraArgs(1)
+	if len(extraArgs) > 1 {
+		selector = selector + "f"
+	}
+
+	return &ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X:   tcall.testingT(),
+			Sel: &ast.Ident{Name: selector},
+		},
+		Args: extraArgs,
+	}
+}
+
+func convertNotEmpty(tcall call, imports importNames) ast.Node {
+	lenExpr := &ast.CallExpr{
+		Fun:  &ast.Ident{Name: "len"},
+		Args: tcall.expr.Args[1:2],
+	}
+	zeroExpr := &ast.BasicLit{Kind: token.INT, Value: "0"}
+	return newCallExprWithPosition(tcall, imports,
+		newCallExprArgs(
+			tcall.testingT(),
+			&ast.BinaryExpr{X: lenExpr, Op: token.NEQ, Y: zeroExpr},
+			tcall.extraArgs(2)...))
+}

--- a/assert/cmd/gty-migrate-from-testify/migrate_test.go
+++ b/assert/cmd/gty-migrate-from-testify/migrate_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
+	"golang.org/x/tools/go/loader"
+)
+
+func TestMigrateFileReplacesTestingT(t *testing.T) {
+	source := `
+package foo
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSomething(t *testing.T) {
+	a := assert.TestingT
+	b := require.TestingT
+	c := require.TestingT(t)
+	if a == b {}
+}
+
+func do(t require.TestingT) {}
+`
+	migration := newMigrationFromSource(t, source)
+	migrateFile(migration)
+
+	expected := `package foo
+
+import (
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/assert"
+)
+
+func TestSomething(t *testing.T) {
+	a := assert.TestingT
+	b := assert.TestingT
+	c := assert.TestingT(t)
+	if a == b {
+	}
+}
+
+func do(t assert.TestingT) {}
+`
+	actual, err := formatFile(migration)
+	assert.NilError(t, err)
+	assert.Assert(t, cmp.EqualMultiLine(expected, string(actual)))
+}
+
+func newMigrationFromSource(t *testing.T, source string) migration {
+	fileset := token.NewFileSet()
+	nodes, err := parser.ParseFile(
+		fileset,
+		"foo.go",
+		source,
+		parser.AllErrors|parser.ParseComments)
+	assert.NilError(t, err)
+
+	opts := options{}
+	conf := loader.Config{
+		Fset:        fileset,
+		ParserMode:  parser.ParseComments,
+		Build:       buildContext(opts),
+		AllowErrors: true,
+	}
+	conf.TypeChecker.Error = func(e error) {}
+	conf.CreateFromFiles("foo.go", nodes)
+	prog, err := conf.Load()
+	assert.NilError(t, err)
+
+	pkgInfo := prog.InitialPackages()[0]
+
+	return migration{
+		file:        pkgInfo.Files[0],
+		fileset:     fileset,
+		importNames: newImportNames(nodes.Imports, opts),
+		pkgInfo:     pkgInfo,
+	}
+}
+
+func TestMigrateFileWithNamedCmpPackage(t *testing.T) {
+	source := `
+package foo
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSomething(t *testing.T) {
+	assert.Equal(t, "a", "b")
+}
+`
+	migration := newMigrationFromSource(t, source)
+	migration.importNames.cmp = "is"
+	migrateFile(migration)
+
+	expected := `package foo
+
+import (
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+)
+
+func TestSomething(t *testing.T) {
+	assert.Check(t, is.Equal("a", "b"))
+}
+`
+	actual, err := formatFile(migration)
+	assert.NilError(t, err)
+	assert.Assert(t, cmp.EqualMultiLine(expected, string(actual)))
+}
+
+func TestMigrateFileWithCommentsOnAssert(t *testing.T) {
+	source := `
+package foo
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSomething(t *testing.T) {
+	// This is going to fail
+	assert.Equal(t, "a", "b")
+}
+`
+	migration := newMigrationFromSource(t, source)
+	migrateFile(migration)
+
+	expected := `package foo
+
+import (
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
+)
+
+func TestSomething(t *testing.T) {
+	// This is going to fail
+	assert.Check(t, cmp.Equal("a", "b"))
+}
+`
+	actual, err := formatFile(migration)
+	assert.NilError(t, err)
+	assert.Assert(t, cmp.EqualMultiLine(expected, string(actual)))
+}
+
+func TestMigrateFileConvertNilToNilError(t *testing.T) {
+	source := `
+package foo
+
+import (
+	"testing"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSomething(t *testing.T) {
+	var err error
+	assert.Nil(t, err)
+	require.Nil(t, err)
+}
+`
+	migration := newMigrationFromSource(t, source)
+	migrateFile(migration)
+
+	expected := `package foo
+
+import (
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
+)
+
+func TestSomething(t *testing.T) {
+	var err error
+	assert.Check(t, cmp.NilError(err))
+	assert.NilError(t, err)
+}
+`
+	actual, err := formatFile(migration)
+	assert.NilError(t, err)
+	assert.Assert(t, cmp.EqualMultiLine(expected, string(actual)))
+}

--- a/assert/cmd/gty-migrate-from-testify/migrate_test.go
+++ b/assert/cmd/gty-migrate-from-testify/migrate_test.go
@@ -52,7 +52,7 @@ func do(t assert.TestingT) {}
 `
 	actual, err := formatFile(migration)
 	assert.NilError(t, err)
-	assert.Assert(t, cmp.EqualMultiLine(expected, string(actual)))
+	assert.Assert(t, cmp.Equal(expected, string(actual)))
 }
 
 func newMigrationFromSource(t *testing.T, source string) migration {
@@ -123,7 +123,7 @@ func TestSomething(t *testing.T) {
 `
 	actual, err := formatFile(migration)
 	assert.NilError(t, err)
-	assert.Assert(t, cmp.EqualMultiLine(expected, string(actual)))
+	assert.Assert(t, cmp.Equal(expected, string(actual)))
 }
 
 func TestMigrateFileWithCommentsOnAssert(t *testing.T) {
@@ -159,7 +159,7 @@ func TestSomething(t *testing.T) {
 `
 	actual, err := formatFile(migration)
 	assert.NilError(t, err)
-	assert.Assert(t, cmp.EqualMultiLine(expected, string(actual)))
+	assert.Assert(t, cmp.Equal(expected, string(actual)))
 }
 
 func TestMigrateFileConvertNilToNilError(t *testing.T) {
@@ -187,18 +187,17 @@ import (
 	"testing"
 
 	"github.com/gotestyourself/gotestyourself/assert"
-	"github.com/gotestyourself/gotestyourself/assert/cmp"
 )
 
 func TestSomething(t *testing.T) {
 	var err error
-	assert.Check(t, cmp.NilError(err))
+	assert.Check(t, err)
 	assert.NilError(t, err)
 }
 `
 	actual, err := formatFile(migration)
 	assert.NilError(t, err)
-	assert.Assert(t, cmp.EqualMultiLine(expected, string(actual)))
+	assert.Assert(t, cmp.Equal(expected, string(actual)))
 }
 
 func TestMigrateFileConvertAssertNew(t *testing.T) {
@@ -244,16 +243,16 @@ func TestSomething(t *testing.T) {
 	assert.Check(t, cmp.Equal("one", "two"))
 	assert.Check(t, "one" != "two")
 
-	assert.Assert(t, cmp.Equal("one", "two"))
+	assert.Equal(t, "one", "two")
 	assert.Assert(t, "one" != "two")
 }
 
 func TestOtherName(z *testing.T) {
 
-	assert.Assert(z, cmp.Equal("one", "two"))
+	assert.Equal(z, "one", "two")
 }
 `
 	actual, err := formatFile(migration)
 	assert.NilError(t, err)
-	assert.Assert(t, cmp.EqualMultiLine(expected, string(actual)))
+	assert.Assert(t, cmp.Equal(expected, string(actual)))
 }

--- a/assert/cmd/gty-migrate-from-testify/testdata/full-expected/some_test.go
+++ b/assert/cmd/gty-migrate-from-testify/testdata/full-expected/some_test.go
@@ -20,19 +20,21 @@ func TestFirstThing(t *testing.T) {
 	assert.Check(t, cmp.Equal(1, 2))
 	assert.Check(t, false)
 	assert.Check(t, !true)
-	assert.NilError(t, nil)
+	assert.NilError(rt, nil)
 
-	assert.Check(t, cmp.Compare(map[string]bool{"a": true}, nil))
-	assert.Check(t, cmp.Compare([]int{1}, nil))
+	assert.Check(t, cmp.DeepEqual(map[string]bool{"a": true}, nil))
+	assert.Check(t, cmp.DeepEqual([]int{1}, nil))
+	assert.Equal(rt, "a", "B")
 }
 
 func TestSecondThing(t *testing.T) {
 	var foo mystruct
-	assert.Assert(t, cmp.Compare(foo, mystruct{}))
+	assert.DeepEqual(t, foo, mystruct{})
 
-	assert.Assert(t, cmp.Compare(mystruct{}, mystruct{}))
+	assert.DeepEqual(t, mystruct{}, mystruct{})
 
-	assert.Check(t, cmp.NilError(nil), "foo %d", 3)
+	assert.Check(t, nil, "foo %d", 3)
+	assert.NilError(t, nil, "foo %d", 3)
 
 	assert.Check(t, cmp.ErrorContains(fmt.Errorf("foo"), ""))
 }
@@ -64,10 +66,10 @@ func TestNotNamedT(c *testing.T) {
 
 func TestEqualsWithComplexTypes(t *testing.T) {
 	expected := []int{1, 2, 3}
-	assert.Check(t, cmp.Compare(expected, nil))
+	assert.Check(t, cmp.DeepEqual(expected, nil))
 
 	expectedM := map[int]bool{}
-	assert.Check(t, cmp.Compare(expectedM, nil))
+	assert.Check(t, cmp.DeepEqual(expectedM, nil))
 
 	expectedI := 123
 	assert.Check(t, cmp.Equal(expectedI, 0))
@@ -111,21 +113,21 @@ func TestTableTest(t *testing.T) {
 
 	for _, testcase := range testcases {
 		assert.Check(t, cmp.Equal(testcase.actual, testcase.expected))
-		assert.Check(t, cmp.Compare(testcase.opts, testcase.expectedOpts))
+		assert.Check(t, cmp.DeepEqual(testcase.opts, testcase.expectedOpts))
 	}
 }
 
 func TestWithChecker(c *check.C) {
 	var err error
-	assert.Check(c, cmp.NilError(err))
+	assert.Check(c, err)
 }
 
 func HelperWithAssertTestingT(t assert.TestingT) {
 	var err error
-	assert.Check(t, cmp.NilError(err), "with assert.TestingT")
+	assert.Check(t, err, "with assert.TestingT")
 }
 
 func BenchmarkSomething(b *testing.B) {
 	var err error
-	assert.Check(b, cmp.NilError(err))
+	assert.Check(b, err)
 }

--- a/assert/cmd/gty-migrate-from-testify/testdata/full-expected/some_test.go
+++ b/assert/cmd/gty-migrate-from-testify/testdata/full-expected/some_test.go
@@ -1,0 +1,116 @@
+package foo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
+)
+
+type mystruct struct {
+	a        int
+	expected int
+}
+
+func TestFirstThing(t *testing.T) {
+	rt := assert.TestingT(t)
+	assert.Check(t, cmp.Equal("foo", "bar"))
+	assert.Check(t, cmp.Equal(1, 2))
+	assert.Check(t, false)
+	assert.Check(t, !true)
+	assert.NilError(t, nil)
+
+	assert.Check(t, cmp.Compare(map[string]bool{"a": true}, nil))
+	assert.Check(t, cmp.Compare([]int{1}, nil))
+}
+
+func TestSecondThing(t *testing.T) {
+	var foo mystruct
+	assert.Assert(t, cmp.Compare(foo, mystruct{}))
+
+	assert.Assert(t, cmp.Compare(mystruct{}, mystruct{}))
+
+	assert.Check(t, cmp.NilError(nil), "foo %d", 3)
+
+	assert.Check(t, cmp.ErrorContains(fmt.Errorf("foo"), ""))
+}
+
+func TestMissed(t *testing.T) {
+	a := assert.New(t)
+
+	a.Equal(t, "a", "b")
+}
+
+type unit struct {
+	c *testing.T
+}
+
+func thing(t *testing.T) unit {
+	return unit{c: t}
+}
+
+func TestStoredTestingT(t *testing.T) {
+	u := thing(t)
+	assert.Check(u.c, cmp.Equal("A", "b"))
+
+	u = unit{c: t}
+	assert.Check(u.c, cmp.Equal("A", "b"))
+}
+
+func TestNotNamedT(c *testing.T) {
+	assert.Check(c, cmp.Equal("A", "b"))
+}
+
+func TestEqualsWithComplexTypes(t *testing.T) {
+	expected := []int{1, 2, 3}
+	assert.Check(t, cmp.Compare(expected, nil))
+
+	expectedM := map[int]bool{}
+	assert.Check(t, cmp.Compare(expectedM, nil))
+
+	expectedI := 123
+	assert.Check(t, cmp.Equal(expectedI, 0))
+
+	assert.Check(t, cmp.Equal(doInt(), 3))
+	// TODO: struct field
+}
+
+func doInt() int {
+	return 1
+}
+
+func TestEqualWithPrimitiveTypes(t *testing.T) {
+	s := "foo"
+	ptrString := &s
+	assert.Check(t, cmp.Equal(*ptrString, "foo"))
+
+	assert.Check(t, cmp.Equal(doInt(), doInt()))
+
+	x := doInt()
+	y := doInt()
+	assert.Check(t, cmp.Equal(x, y))
+
+	tc := mystruct{a: 3, expected: 5}
+	assert.Check(t, cmp.Equal(tc.a, tc.expected))
+}
+
+func TestTableTest(t *testing.T) {
+	var testcases = []struct {
+		opts         []string
+		actual       string
+		expected     string
+		expectedOpts []string
+	}{
+		{
+			opts:     []string{"a", "b"},
+			actual:   "foo",
+			expected: "else",
+		},
+	}
+
+	for _, testcase := range testcases {
+		assert.Check(t, cmp.Equal(testcase.actual, testcase.expected))
+		assert.Check(t, cmp.Compare(testcase.opts, testcase.expectedOpts))
+	}
+}

--- a/assert/cmd/gty-migrate-from-testify/testdata/full-expected/some_test.go
+++ b/assert/cmd/gty-migrate-from-testify/testdata/full-expected/some_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-check/check"
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/gotestyourself/gotestyourself/assert/cmp"
 )
@@ -36,10 +37,9 @@ func TestSecondThing(t *testing.T) {
 	assert.Check(t, cmp.ErrorContains(fmt.Errorf("foo"), ""))
 }
 
-func TestMissed(t *testing.T) {
-	a := assert.New(t)
+func TestAssertNew(t *testing.T) {
 
-	a.Equal(t, "a", "b")
+	assert.Check(t, cmp.Equal("a", "b"))
 }
 
 type unit struct {
@@ -113,4 +113,19 @@ func TestTableTest(t *testing.T) {
 		assert.Check(t, cmp.Equal(testcase.actual, testcase.expected))
 		assert.Check(t, cmp.Compare(testcase.opts, testcase.expectedOpts))
 	}
+}
+
+func TestWithChecker(c *check.C) {
+	var err error
+	assert.Check(c, cmp.NilError(err))
+}
+
+func HelperWithAssertTestingT(t assert.TestingT) {
+	var err error
+	assert.Check(t, cmp.NilError(err), "with assert.TestingT")
+}
+
+func BenchmarkSomething(b *testing.B) {
+	var err error
+	assert.Check(b, cmp.NilError(err))
 }

--- a/assert/cmd/gty-migrate-from-testify/testdata/full/some_test.go
+++ b/assert/cmd/gty-migrate-from-testify/testdata/full/some_test.go
@@ -20,10 +20,11 @@ func TestFirstThing(t *testing.T) {
 	assert.Equal(t, 1, 2)
 	assert.True(t, false)
 	assert.False(t, true)
-	require.NoError(t, nil)
+	require.NoError(rt, nil)
 
 	assert.Equal(t, map[string]bool{"a": true}, nil)
 	assert.Equal(t, []int{1}, nil)
+	require.Equal(rt, "a", "B")
 }
 
 func TestSecondThing(t *testing.T) {
@@ -33,6 +34,7 @@ func TestSecondThing(t *testing.T) {
 	require.Equal(t, mystruct{}, mystruct{})
 
 	assert.NoError(t, nil, "foo %d", 3)
+	require.NoError(t, nil, "foo %d", 3)
 
 	assert.Error(t, fmt.Errorf("foo"))
 }

--- a/assert/cmd/gty-migrate-from-testify/testdata/full/some_test.go
+++ b/assert/cmd/gty-migrate-from-testify/testdata/full/some_test.go
@@ -1,0 +1,116 @@
+package foo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mystruct struct {
+	a        int
+	expected int
+}
+
+func TestFirstThing(t *testing.T) {
+	rt := require.TestingT(t)
+	assert.Equal(t, "foo", "bar")
+	assert.Equal(t, 1, 2)
+	assert.True(t, false)
+	assert.False(t, true)
+	require.NoError(t, nil)
+
+	assert.Equal(t, map[string]bool{"a": true}, nil)
+	assert.Equal(t, []int{1}, nil)
+}
+
+func TestSecondThing(t *testing.T) {
+	var foo mystruct
+	require.Equal(t, foo, mystruct{})
+
+	require.Equal(t, mystruct{}, mystruct{})
+
+	assert.NoError(t, nil, "foo %d", 3)
+
+	assert.Error(t, fmt.Errorf("foo"))
+}
+
+func TestMissed(t *testing.T) {
+	a := assert.New(t)
+
+	a.Equal(t, "a", "b")
+}
+
+type unit struct {
+	c *testing.T
+}
+
+func thing(t *testing.T) unit {
+	return unit{c: t}
+}
+
+func TestStoredTestingT(t *testing.T) {
+	u := thing(t)
+	assert.Equal(u.c, "A", "b")
+
+	u = unit{c: t}
+	assert.Equal(u.c, "A", "b")
+}
+
+func TestNotNamedT(c *testing.T) {
+	assert.Equal(c, "A", "b")
+}
+
+func TestEqualsWithComplexTypes(t *testing.T) {
+	expected := []int{1, 2, 3}
+	assert.Equal(t, expected, nil)
+
+	expectedM := map[int]bool{}
+	assert.Equal(t, expectedM, nil)
+
+	expectedI := 123
+	assert.Equal(t, expectedI, 0)
+
+	assert.Equal(t, doInt(), 3)
+	// TODO: struct field
+}
+
+func doInt() int {
+	return 1
+}
+
+func TestEqualWithPrimitiveTypes(t *testing.T) {
+	s := "foo"
+	ptrString := &s
+	assert.Equal(t, *ptrString, "foo")
+
+	assert.Equal(t, doInt(), doInt())
+
+	x := doInt()
+	y := doInt()
+	assert.Equal(t, x, y)
+
+	tc := mystruct{a: 3, expected: 5}
+	assert.Equal(t, tc.a, tc.expected)
+}
+
+func TestTableTest(t *testing.T) {
+	var testcases = []struct {
+		opts         []string
+		actual       string
+		expected     string
+		expectedOpts []string
+	}{
+		{
+			opts:     []string{"a", "b"},
+			actual:   "foo",
+			expected: "else",
+		},
+	}
+
+	for _, testcase := range testcases {
+		assert.Equal(t, testcase.actual, testcase.expected)
+		assert.Equal(t, testcase.opts, testcase.expectedOpts)
+	}
+}

--- a/assert/cmd/gty-migrate-from-testify/testdata/full/some_test.go
+++ b/assert/cmd/gty-migrate-from-testify/testdata/full/some_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-check/check"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,10 +37,10 @@ func TestSecondThing(t *testing.T) {
 	assert.Error(t, fmt.Errorf("foo"))
 }
 
-func TestMissed(t *testing.T) {
+func TestAssertNew(t *testing.T) {
 	a := assert.New(t)
 
-	a.Equal(t, "a", "b")
+	a.Equal("a", "b")
 }
 
 type unit struct {
@@ -113,4 +114,19 @@ func TestTableTest(t *testing.T) {
 		assert.Equal(t, testcase.actual, testcase.expected)
 		assert.Equal(t, testcase.opts, testcase.expectedOpts)
 	}
+}
+
+func TestWithChecker(c *check.C) {
+	var err error
+	assert.NoError(c, err)
+}
+
+func HelperWithAssertTestingT(t assert.TestingT) {
+	var err error
+	assert.NoError(t, err, "with assert.TestingT")
+}
+
+func BenchmarkSomething(b *testing.B) {
+	var err error
+	assert.NoError(b, err)
 }

--- a/assert/cmd/gty-migrate-from-testify/walktype.go
+++ b/assert/cmd/gty-migrate-from-testify/walktype.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/loader"
+)
+
+// walkForType walks the AST tree and returns the type of the expression
+func walkForType(pkgInfo *loader.PackageInfo, node ast.Node) types.Type {
+	var result types.Type
+
+	visit := func(node ast.Node) bool {
+		if expr, ok := node.(ast.Expr); ok {
+			if typeAndValue, ok := pkgInfo.Types[expr]; ok {
+				result = typeAndValue.Type
+				return false
+			}
+		}
+		return true
+	}
+	ast.Inspect(node, visit)
+	return result
+}
+
+func isUnknownType(typ types.Type) bool {
+	if typ == nil {
+		return true
+	}
+	basic, ok := typ.(*types.Basic)
+	return ok && basic.Kind() == types.Invalid
+}

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -32,6 +32,7 @@ job=watch:
   mounts: [source]
   interactive: true
   command: scripts/watch
+  env: ['TESTFLAGS={env.TESTFLAGS:}']
 
 job=test-unit:
   use: builder

--- a/dobifiles/Dockerfile
+++ b/dobifiles/Dockerfile
@@ -17,5 +17,6 @@ RUN     go get -d github.com/golang/dep/cmd/dep && \
         go build -v -o /usr/bin/dep ./cmd/dep && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
+ENV     PS1="# "
 WORKDIR /go/src/github.com/gotestyourself/gotestyourself
 ENV     CGO_ENABLED=0

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -2,7 +2,10 @@
   "Vendor": true,
   "Deadline": "2m",
   "Sort": ["linter", "severity", "path"],
-  "Exclude": ["example_test\\.go"],
+  "Exclude": [
+    "example_test\\.go",
+    "assert/cmd/gty-migrate-from-testify/testdata"
+  ],
 
   "Enable": [
     "deadcode",

--- a/scripts/binary-gty-migrate-from-testify
+++ b/scripts/binary-gty-migrate-from-testify
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec go build -o ./dist/gty-migrate-from-testify ./assert/cmd/gty-migrate-from-testify

--- a/scripts/ci/test
+++ b/scripts/ci/test
@@ -10,6 +10,7 @@ docker build \
     -f "$dockerfile" \
     --build-arg GOLANG_VERSION="$golang_version" \
     --tag "$image" .
-docker run --name \
-    "test-$CIRCLE_BUILD_NUM" "$image" \
+docker run \
+    -e TESTTIMEOUT=30s \
+    --name "test-$CIRCLE_BUILD_NUM" "$image" \
     bash -ec 'dep ensure; scripts/binary-testsum; scripts/test-unit'

--- a/scripts/test-unit
+++ b/scripts/test-unit
@@ -2,4 +2,5 @@
 set -eu -o pipefail
 
 paths=${@:-$(go list ./... | grep -v '/vendor/')}
-go test -test.timeout 10s -v $paths | ./dist/gotestsum
+TESTFLAGS=${TESTFLAGS-}
+go test -test.timeout 10s $TESTFLAGS -v $paths | ./dist/gotestsum

--- a/scripts/test-unit
+++ b/scripts/test-unit
@@ -3,4 +3,5 @@ set -eu -o pipefail
 
 paths=${@:-$(go list ./... | grep -v '/vendor/')}
 TESTFLAGS=${TESTFLAGS-}
-go test -test.timeout 10s $TESTFLAGS -v $paths | ./dist/gotestsum
+TESTTIMEOUT=${TESTTIMEOUT-10s}
+go test -test.timeout "$TESTTIMEOUT" $TESTFLAGS -v $paths | ./dist/gotestsum


### PR DESCRIPTION
Branched from #34

Adds a tool for migrating a repo from testify assertions to gotestyourself/assert.

I've used this tool on a few repos and it seems to convert most cases. There are a few things it won't convert:
* assertions that are not part of gotestyourself (because their use should be discouraged, or very rare), ex: Regexp, InDelta
* `require.New(t)` , and any assertions on the returned object. This could be handled with a little more work, but I've never seen this used extensively, so I think it makes sense to wait to support this.

Any skipped assertion is printed to stderr, so it's easy to see how many will be skipped using `--dry-run`. If there are assertions that are not converted, but can be supported by gotestyourself/assert then I would consider that a bug. 

You can see some of the results here (the automated migration commit is separate from any vendor changes or manual changes):
* https://github.com/dnephin/dobi/pull/122
* https://github.com/dnephin/docker/commits/use-gty-assert
* https://github.com/dnephin/cli/commits/update-assertions