### PR TITLE
Improve error Asserts

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -23,7 +23,7 @@ The example below shows assert used with some common types.
 
 	func TestEverything(t *testing.T) {
 	    // booleans
-	    assert.Assert(t, isOk)
+	    assert.Assert(t, ok)
 	    assert.Assert(t, !missing)
 
 	    // primitives
@@ -35,6 +35,7 @@ The example below shows assert used with some common types.
 	    assert.NilError(t, closer.Close())
 	    assert.Assert(t, is.Error(err, "the exact error message"))
 	    assert.Assert(t, is.ErrorContains(err, "includes this"))
+	    assert.Assert(t, os.IsNotExist(err), "got %+v", err)
 
 	    // complex types
 	    assert.Assert(t, is.Len(items, 3))

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -71,7 +71,7 @@ func Len(seq interface{}, expected int) func() (bool, string) {
 func NilError(arg interface{}, args ...interface{}) func() (bool, string) {
 	return func() (bool, string) {
 		msgFunc := func(value reflect.Value) string {
-			return fmt.Sprintf("error is not nil: %s", value.Interface().(error).Error())
+			return fmt.Sprintf("error is not nil: %+v", value.Interface().(error))
 		}
 		if len(args) == 0 {
 			return isNil(arg, msgFunc)()
@@ -170,7 +170,7 @@ func Error(err error, message string) func() (bool, string) {
 			return false, "expected an error, got nil"
 		case err.Error() != message:
 			return false, fmt.Sprintf(
-				"expected error message %q, got %q", message, err.Error())
+				"expected error %q, got %+v", message, err)
 		}
 		return true, ""
 	}
@@ -185,7 +185,7 @@ func ErrorContains(err error, substring string) func() (bool, string) {
 			return false, "expected an error, got nil"
 		case !strings.Contains(err.Error(), substring):
 			return false, fmt.Sprintf(
-				"expected error message to contain %q, got %q", substring, err.Error())
+				"expected error to contain %q, got %+v", substring, err)
 		}
 		return true, ""
 	}

--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -264,8 +265,8 @@ func TestError(t *testing.T) {
 	assertFailure(t, success, message, "expected an error, got nil")
 
 	success, message = Error(errors.New("other"), "the error message")()
-	assertFailure(t, success, message,
-		`expected error message "the error message", got "other"`)
+	assertFailureHasPrefix(t, success, message,
+		`expected error "the error message", got other`)
 
 	msg := "the message"
 	success, message = Error(errors.New(msg), msg)()
@@ -277,8 +278,8 @@ func TestErrorContains(t *testing.T) {
 	assertFailure(t, success, message, "expected an error, got nil")
 
 	success, message = ErrorContains(errors.New("other"), "the error")()
-	assertFailure(t, success, message,
-		`expected error message to contain "the error", got "other"`)
+	assertFailureHasPrefix(t, success, message,
+		`expected error to contain "the error", got other`)
 
 	msg := "the full message"
 	success, message = ErrorContains(errors.New(msg), "full")()
@@ -334,5 +335,17 @@ func assertFailure(t testingT, success bool, message string, expected string) {
 	}
 	if message != expected {
 		t.Errorf("expected \n%q\ngot\n%q\n", expected, message)
+	}
+}
+
+func assertFailureHasPrefix(t testingT, success bool, message string, prefix string) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	if success {
+		t.Errorf("expected failure")
+	}
+	if !strings.HasPrefix(message, prefix) {
+		t.Errorf("expected \n%v\nto start with\n%v\n", message, prefix)
 	}
 }


### PR DESCRIPTION
Add example of using an IsErr function to the godoc
Use %+v to print errors, includes stack when used with pkg/errors