### PR TITLE
Rename Compare to DeepEqual

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -74,16 +74,8 @@ import (
 	"github.com/gotestyourself/gotestyourself/internal/source"
 )
 
-// BoolOrComparison can be a bool, or Comparison. Other types will panic.
+// BoolOrComparison can be a bool, or cmp.Comparison. Other types will panic.
 type BoolOrComparison interface{}
-
-// Comparison is a function which compares values and returns true if the actual
-// value matches the expected value. If the values do not match it returns a message
-// with details about why it failed.
-//
-// https://godoc.org/github.com/gotestyourself/gotestyourself/assert/cmp
-// provides many general purpose Comparisons.
-type Comparison func() (success bool, message string)
 
 // TestingT is the subset of testing.T used by the assert package.
 type TestingT interface {
@@ -126,7 +118,7 @@ func assert(
 		failer()
 		return false
 
-	case Comparison:
+	case cmp.Comparison:
 		return runCompareFunc(failer, t, check, msgAndArgs...)
 
 	case func() (success bool, message string):
@@ -137,7 +129,7 @@ func assert(
 	}
 }
 
-func runCompareFunc(failer func(), t TestingT, f Comparison, msgAndArgs ...interface{}) bool {
+func runCompareFunc(failer func(), t TestingT, f cmp.Comparison, msgAndArgs ...interface{}) bool {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -40,7 +40,7 @@ The example below shows assert used with some common types.
 	    assert.Assert(t, is.Len(items, 3))
 	    assert.Assert(t, len(sequence) != 0) // NotEmpty
 	    assert.Assert(t, is.Contains(mapping, "key"))
-	    assert.Assert(t, is.Compare(result, myStruct{Name: "title"}))
+	    assert.Assert(t, is.DeepEqual(result, myStruct{Name: "title"}))
 
 	    // pointers and interface
 	    assert.Assert(t, is.Nil(ref))

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -10,11 +10,11 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 )
 
-// Compare two complex values using https://godoc.org/github.com/google/go-cmp/cmp
+// DeepEqual compares two values using https://godoc.org/github.com/google/go-cmp/cmp
 // and succeeds if the values are equal.
 //
 // The comparison can be customized using comparison Options.
-func Compare(x, y interface{}, opts ...cmp.Option) func() (bool, string) {
+func DeepEqual(x, y interface{}, opts ...cmp.Option) func() (bool, string) {
 	return func() (success bool, msg string) {
 		defer func() {
 			if panicmsg, handled := handleCmpPanic(recover()); handled {

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -10,11 +10,16 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 )
 
+// Comparison is a function which compares values and returns true if the actual
+// value matches the expected value. If the values do not match it returns a message
+// with details about why it failed.
+type Comparison func() (success bool, message string)
+
 // DeepEqual compares two values using https://godoc.org/github.com/google/go-cmp/cmp
 // and succeeds if the values are equal.
 //
 // The comparison can be customized using comparison Options.
-func DeepEqual(x, y interface{}, opts ...cmp.Option) func() (bool, string) {
+func DeepEqual(x, y interface{}, opts ...cmp.Option) Comparison {
 	return func() (success bool, msg string) {
 		defer func() {
 			if panicmsg, handled := handleCmpPanic(recover()); handled {
@@ -49,7 +54,7 @@ func Equal(x, y interface{}) func() (success bool, message string) {
 }
 
 // Len succeeds if the sequence has the expected length.
-func Len(seq interface{}, expected int) func() (bool, string) {
+func Len(seq interface{}, expected int) Comparison {
 	return func() (success bool, message string) {
 		defer func() {
 			if e := recover(); e != nil {
@@ -68,7 +73,7 @@ func Len(seq interface{}, expected int) func() (bool, string) {
 }
 
 // NilError succeeds if the last argument is a nil error.
-func NilError(arg interface{}, args ...interface{}) func() (bool, string) {
+func NilError(arg interface{}, args ...interface{}) Comparison {
 	return func() (bool, string) {
 		msgFunc := func(value reflect.Value) string {
 			return fmt.Sprintf("error is not nil: %s", value.Interface().(error).Error())
@@ -88,7 +93,7 @@ func NilError(arg interface{}, args ...interface{}) func() (bool, string) {
 // If collection is a Map, contains will succeed if item is a key in the map.
 // If collection is a slice or array, item is compared to each item in the
 // sequence using reflect.DeepEqual().
-func Contains(collection interface{}, item interface{}) func() (bool, string) {
+func Contains(collection interface{}, item interface{}) Comparison {
 	return func() (bool, string) {
 		colValue := reflect.ValueOf(collection)
 		if !colValue.IsValid() {
@@ -127,7 +132,7 @@ func Contains(collection interface{}, item interface{}) func() (bool, string) {
 }
 
 // Panics succeeds if f() panics.
-func Panics(f func()) func() (bool, string) {
+func Panics(f func()) Comparison {
 	return func() (success bool, message string) {
 		defer func() {
 			if err := recover(); err != nil {
@@ -141,7 +146,7 @@ func Panics(f func()) func() (bool, string) {
 
 // EqualMultiLine succeeds if the two strings are equal. If they are not equal
 // the failure message will be the difference between the two strings.
-func EqualMultiLine(x, y string) func() (bool, string) {
+func EqualMultiLine(x, y string) Comparison {
 	return func() (bool, string) {
 		if x == y {
 			return true, ""
@@ -163,7 +168,7 @@ func EqualMultiLine(x, y string) func() (bool, string) {
 
 // Error succeeds if err is a non-nil error, and the error message equals the
 // expected message.
-func Error(err error, message string) func() (bool, string) {
+func Error(err error, message string) Comparison {
 	return func() (bool, string) {
 		switch {
 		case err == nil:
@@ -178,7 +183,7 @@ func Error(err error, message string) func() (bool, string) {
 
 // ErrorContains succeeds if err is a non-nil error, and the error message contains
 // the expected substring.
-func ErrorContains(err error, substring string) func() (bool, string) {
+func ErrorContains(err error, substring string) Comparison {
 	return func() (bool, string) {
 		switch {
 		case err == nil:
@@ -195,14 +200,14 @@ func ErrorContains(err error, substring string) func() (bool, string) {
 //
 // Use NilError() for comparing errors. Use Len(obj, 0) for comparing slices,
 // maps, and channels.
-func Nil(obj interface{}) func() (bool, string) {
+func Nil(obj interface{}) Comparison {
 	msgFunc := func(value reflect.Value) string {
 		return fmt.Sprintf("%v (type %s) is not nil", reflect.Indirect(value), value.Type())
 	}
 	return isNil(obj, msgFunc)
 }
 
-func isNil(obj interface{}, msgFunc func(reflect.Value) string) func() (bool, string) {
+func isNil(obj interface{}, msgFunc func(reflect.Value) string) Comparison {
 	return func() (bool, string) {
 		if obj == nil {
 			return true, ""

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -44,10 +44,10 @@ func TestPatchAll(t *testing.T) {
 
 	actual := os.Environ()
 	sort.Strings(actual)
-	assert.Assert(t, cmp.Compare([]string{"FIRST=STARS", "THEN=MOON"}, actual))
+	assert.Assert(t, cmp.DeepEqual([]string{"FIRST=STARS", "THEN=MOON"}, actual))
 
 	revert()
-	assert.Assert(t, cmp.Compare(sorted(oldEnv), sorted(os.Environ())))
+	assert.Assert(t, cmp.DeepEqual(sorted(oldEnv), sorted(os.Environ())))
 }
 
 func sorted(source []string) []string {
@@ -59,5 +59,5 @@ func TestToMap(t *testing.T) {
 	source := []string{"key=value", "novaluekey"}
 	actual := ToMap(source)
 	expected := map[string]string{"key": "value", "novaluekey": ""}
-	assert.Assert(t, cmp.Compare(expected, actual))
+	assert.Assert(t, cmp.DeepEqual(expected, actual))
 }

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -87,5 +87,5 @@ func AssertBytes(t assert.TestingT, actual []byte, filename string, msgAndArgs .
 	}
 	update(t, filename, actual)
 	expected := Get(t, filename)
-	return assert.Check(t, cmp.Compare(expected, actual), msgAndArgs...)
+	return assert.Check(t, cmp.DeepEqual(expected, actual), msgAndArgs...)
 }

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -52,7 +52,7 @@ func TestGoldenGet(t *testing.T) {
 
 	actual := Get(fakeT, filename)
 	assert.Assert(t, !fakeT.Failed)
-	assert.Assert(t, cmp.Compare(actual, []byte(expected)))
+	assert.Assert(t, cmp.DeepEqual(actual, []byte(expected)))
 }
 
 func TestGoldenAssertInvalidContent(t *testing.T) {

--- a/testsum/scan_test.go
+++ b/testsum/scan_test.go
@@ -16,7 +16,7 @@ func compare(x, y interface{}) func() (bool, string) {
 	elapsedPath := func(path gocmp.Path) bool {
 		return path.Last().String() == ".Elapsed"
 	}
-	return cmp.Compare(x, y,
+	return cmp.DeepEqual(x, y,
 		gocmp.AllowUnexported(Failure{}),
 		gocmp.FilterPath(elapsedPath, gocmp.Ignore()))
 }


### PR DESCRIPTION
Fixes #44

Also moves `Comparison` from the assert package to the `cmp` package. This will improve the godoc (because the types can now return `Comparison` instead of just a function), and will make things more consistent when other types of Comparison are added.

Neither of these changes are backwards compatible, but they aren't in a tagged release yet, so we should be ok to make these breaking changes.