### PR TITLE
Change Comparison to return a Result

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -69,6 +69,7 @@ package assert
 
 import (
 	"fmt"
+	"go/ast"
 
 	"github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/internal/format"
@@ -89,57 +90,70 @@ type helperT interface {
 	Helper()
 }
 
-// stackIndex = Assert()/Check(), assert()
-const stackIndex = 2
-const comparisonArgPos = 1
-
 const failureMessage = "assertion failed: "
 
 func assert(
 	t TestingT,
 	failer func(),
+	argsFilter func([]ast.Expr) []ast.Expr,
 	comparison BoolOrComparison,
 	msgAndArgs ...interface{},
 ) bool {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
+	var success bool
 	switch check := comparison.(type) {
 	case bool:
 		if check {
 			return true
 		}
-		source, err := source.GetCondition(stackIndex, comparisonArgPos)
-		if err != nil {
-			t.Log(err.Error())
-		}
-
-		msg := " is false"
-		t.Log(format.WithCustomMessage(failureMessage+source+msg, msgAndArgs...))
-		failer()
-		return false
+		logFailureFromBool(t, msgAndArgs...)
 
 	case cmp.Comparison:
-		return runCompareFunc(failer, t, check, msgAndArgs...)
+		success = runCompareFunc(t, check, msgAndArgs...)
 
 	case func() (success bool, message string):
-		return runCompareFunc(failer, t, check, msgAndArgs...)
+		success = runCompareFunc(t, check, msgAndArgs...)
+
+	case cmp.ComparisonWithResult:
+		success = runCompareWithResultFunc(t, argsFilter, check, msgAndArgs...)
+
+	case func() cmp.Result:
+		success = runCompareWithResultFunc(t, argsFilter, check, msgAndArgs...)
 
 	default:
 		panic(fmt.Sprintf("comparison arg must be bool or Comparison, not %T", comparison))
 	}
+
+	if success {
+		return true
+	}
+	failer()
+	return false
 }
 
-func runCompareFunc(failer func(), t TestingT, f cmp.Comparison, msgAndArgs ...interface{}) bool {
+func runCompareFunc(t TestingT, f cmp.Comparison, msgAndArgs ...interface{}) bool {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
 	if success, message := f(); !success {
 		t.Log(format.WithCustomMessage(failureMessage+message, msgAndArgs...))
-		failer()
 		return false
 	}
 	return true
+}
+
+func logFailureFromBool(t TestingT, msgAndArgs ...interface{}) {
+	const stackIndex = 3 // Assert()/Check(), assert(), formatFailureFromBool()
+	const comparisonArgPos = 1
+	source, err := source.FormattedCallExprArg(stackIndex, comparisonArgPos)
+	if err != nil {
+		t.Log(err.Error())
+	}
+
+	msg := " is false"
+	t.Log(format.WithCustomMessage(failureMessage+source+msg, msgAndArgs...))
 }
 
 // Assert performs a comparison, marks the test as having failed if the comparison
@@ -148,7 +162,7 @@ func Assert(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) 
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	assert(t, t.FailNow, comparison, msgAndArgs...)
+	assert(t, t.FailNow, filterExprArgsFromComparison, comparison, msgAndArgs...)
 }
 
 // Check performs a comparison and marks the test as having failed if the comparison
@@ -157,7 +171,7 @@ func Check(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) b
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	return assert(t, t.Fail, comparison, msgAndArgs...)
+	return assert(t, t.Fail, filterExprArgsFromComparison, comparison, msgAndArgs...)
 }
 
 // NilError fails the test immediately if the last arg is a non-nil error.
@@ -166,7 +180,7 @@ func NilError(t TestingT, err error, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	assert(t, t.FailNow, cmp.NilError(err), msgAndArgs...)
+	assert(t, t.FailNow, filterExprExcludeFirst, cmp.NilError(err), msgAndArgs...)
 }
 
 // Equal uses the == operator to assert two values are equal and fails the test
@@ -175,5 +189,5 @@ func Equal(t TestingT, x, y interface{}, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	assert(t, t.FailNow, cmp.Equal(x, y), msgAndArgs...)
+	assert(t, t.FailNow, filterExprExcludeFirst, cmp.Equal(x, y), msgAndArgs...)
 }

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -187,6 +187,15 @@ func TestEqualFailureWithSelectorArgument(t *testing.T) {
 		"assertion failed: ok (string) != foo (testcase.expected string)")
 }
 
+func TestEqualFailureWithIndexExpr(t *testing.T) {
+	fakeT := &fakeTestingT{}
+
+	expected := map[string]string{"foo": "bar"}
+	Equal(fakeT, "ok", expected["foo"])
+	expectFailNowed(t, fakeT,
+		`assertion failed: ok (string) != bar (expected["foo"] string)`)
+}
+
 func TestEqualFailureWithCallExprArgument(t *testing.T) {
 	fakeT := &fakeTestingT{}
 	ce := customError{}

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -3,6 +3,8 @@ package assert
 import (
 	"fmt"
 	"testing"
+
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
 )
 
 type fakeTestingT struct {
@@ -139,6 +141,14 @@ func TestCheckSuccess(t *testing.T) {
 	expectSuccess(t, fakeT)
 }
 
+func TestCheckEqualFailure(t *testing.T) {
+	fakeT := &fakeTestingT{}
+
+	actual, expected := 5, 9
+	Check(fakeT, cmp.Equal(actual, expected))
+	expectFailed(t, fakeT, "assertion failed: 5 (actual int) != 9 (expected int)")
+}
+
 func TestEqualSuccess(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
@@ -152,8 +162,9 @@ func TestEqualSuccess(t *testing.T) {
 func TestEqualFailure(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
-	Equal(fakeT, 1, 3)
-	expectFailNowed(t, fakeT, "assertion failed: 1 (int) != 3 (int)")
+	actual, expected := 1, 3
+	Equal(fakeT, actual, expected)
+	expectFailNowed(t, fakeT, "assertion failed: 1 (actual int) != 3 (expected int)")
 }
 
 func TestEqualFailureTypes(t *testing.T) {
@@ -161,6 +172,27 @@ func TestEqualFailureTypes(t *testing.T) {
 
 	Equal(fakeT, 3, uint(3))
 	expectFailNowed(t, fakeT, `assertion failed: 3 (int) != 3 (uint)`)
+}
+
+func TestEqualFailureWithSelectorArgument(t *testing.T) {
+	fakeT := &fakeTestingT{}
+
+	type tc struct {
+		expected string
+	}
+	var testcase = tc{expected: "foo"}
+
+	Equal(fakeT, "ok", testcase.expected)
+	expectFailNowed(t, fakeT,
+		"assertion failed: ok (string) != foo (testcase.expected string)")
+}
+
+func TestEqualFailureWithCallExprArgument(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	ce := customError{}
+	Equal(fakeT, "", ce.Error())
+	expectFailNowed(t, fakeT,
+		"assertion failed:  (string) != custom error (string)")
 }
 
 type testingT interface {

--- a/assert/cmp/result.go
+++ b/assert/cmp/result.go
@@ -9,12 +9,31 @@ import (
 	"github.com/gotestyourself/gotestyourself/internal/source"
 )
 
-// TODO: deprecate old (string, bool) result in favor of another interface?
-
 // Result of a Comparison.
 type Result interface {
-	// Success returns true if the comparison was successful.
 	Success() bool
+}
+
+type result struct {
+	success bool
+	message string
+}
+
+func (r result) Success() bool {
+	return r.success
+}
+
+func (r result) FailureMessage() string {
+	return r.message
+}
+
+// ResultSuccess is a constant which is returned by a ComparisonWithResult to
+// indicate success.
+var ResultSuccess = result{success: true}
+
+// ResultFailure returns a failed Result with a failure message.
+func ResultFailure(message string) Result {
+	return result{message: message}
 }
 
 type templatedResult struct {
@@ -35,13 +54,11 @@ func (r templatedResult) FailureMessage(args []ast.Expr) string {
 	return msg
 }
 
-// ResultSuccess is a constant which is returned by a ComparisonWithResult to
-// indicate success.
-var ResultSuccess = templatedResult{success: true}
-
-// TemplatedResultFailure returns a Result with a template string and data which will be
-// used to format a failure message.
-func TemplatedResultFailure(template string, data map[string]interface{}) Result {
+// ResultFailureTemplate returns a Result with a template string and data which will be
+// used to format a failure message. The template may access data from .Data,
+// the comparison args as .Args ([]ast.Expr), and the formatNode function for
+// formatting the args.
+func ResultFailureTemplate(template string, data map[string]interface{}) Result {
 	return templatedResult{template: template, data: data}
 }
 

--- a/assert/cmp/result.go
+++ b/assert/cmp/result.go
@@ -1,0 +1,63 @@
+package cmp
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"text/template"
+
+	"github.com/gotestyourself/gotestyourself/internal/source"
+)
+
+// TODO: deprecate old (string, bool) result in favor of another interface?
+
+// Result of a Comparison.
+type Result interface {
+	// Success returns true if the comparison was successful.
+	Success() bool
+}
+
+type templatedResult struct {
+	success  bool
+	template string
+	data     map[string]interface{}
+}
+
+func (r templatedResult) Success() bool {
+	return r.success
+}
+
+func (r templatedResult) FailureMessage(args []ast.Expr) string {
+	msg, err := renderMessage(r, args)
+	if err != nil {
+		return fmt.Sprintf("failed to render failure message: %s", err)
+	}
+	return msg
+}
+
+// ResultSuccess is a constant which is returned by a ComparisonWithResult to
+// indicate success.
+var ResultSuccess = templatedResult{success: true}
+
+// TemplatedResultFailure returns a Result with a template string and data which will be
+// used to format a failure message.
+func TemplatedResultFailure(template string, data map[string]interface{}) Result {
+	return templatedResult{template: template, data: data}
+}
+
+func renderMessage(result templatedResult, args []ast.Expr) (string, error) {
+	tmpl, err := template.New("failure").Funcs(tmplFuncs).Parse(result.template)
+	if err != nil {
+		return "", err
+	}
+	buf := new(bytes.Buffer)
+	err = tmpl.Execute(buf, map[string]interface{}{
+		"Data": result.data,
+		"Args": args,
+	})
+	return buf.String(), err
+}
+
+var tmplFuncs = template.FuncMap{
+	"formatNode": source.FormatNode,
+}

--- a/assert/result.go
+++ b/assert/result.go
@@ -9,10 +9,10 @@ import (
 	"github.com/gotestyourself/gotestyourself/internal/source"
 )
 
-func runCompareWithResultFunc(
+func runComparison(
 	t TestingT,
 	argsFilter astExprListFilter,
-	f cmp.ComparisonWithResult,
+	f cmp.Comparison,
 	msgAndArgs ...interface{},
 ) bool {
 	if ht, ok := t.(helperT); ok {
@@ -26,12 +26,14 @@ func runCompareWithResultFunc(
 	var message string
 	switch typed := result.(type) {
 	case resultWithComparisonArgs:
-		const stackIndex = 3 // Assert/Check, assert, runCompareWithResultFunc
+		const stackIndex = 3 // Assert/Check, assert, runComparison
 		args, err := source.CallExprArgs(stackIndex)
 		if err != nil {
 			t.Log(err.Error())
 		}
 		message = typed.FailureMessage(argsFilter(args))
+	case resultBasic:
+		message = typed.FailureMessage()
 	default:
 		message = fmt.Sprintf("comparison returned invalid Result type: %T", result)
 	}
@@ -42,6 +44,10 @@ func runCompareWithResultFunc(
 
 type resultWithComparisonArgs interface {
 	FailureMessage(args []ast.Expr) string
+}
+
+type resultBasic interface {
+	FailureMessage() string
 }
 
 type astExprListFilter func([]ast.Expr) []ast.Expr

--- a/assert/result.go
+++ b/assert/result.go
@@ -1,0 +1,82 @@
+package assert
+
+import (
+	"fmt"
+	"go/ast"
+
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/gotestyourself/gotestyourself/internal/format"
+	"github.com/gotestyourself/gotestyourself/internal/source"
+)
+
+func runCompareWithResultFunc(
+	t TestingT,
+	argsFilter astExprListFilter,
+	f cmp.ComparisonWithResult,
+	msgAndArgs ...interface{},
+) bool {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	result := f()
+	if result.Success() {
+		return true
+	}
+
+	var message string
+	switch typed := result.(type) {
+	case resultWithComparisonArgs:
+		const stackIndex = 3 // Assert/Check, assert, runCompareWithResultFunc
+		args, err := source.CallExprArgs(stackIndex)
+		if err != nil {
+			t.Log(err.Error())
+		}
+		message = typed.FailureMessage(argsFilter(args))
+	default:
+		message = fmt.Sprintf("comparison returned invalid Result type: %T", result)
+	}
+
+	t.Log(format.WithCustomMessage(failureMessage+message, msgAndArgs...))
+	return false
+}
+
+type resultWithComparisonArgs interface {
+	FailureMessage(args []ast.Expr) string
+}
+
+type astExprListFilter func([]ast.Expr) []ast.Expr
+
+// filterArgs filters the ast.Expr slice to only include nodes that are easy to
+// read when printed and contain relevant information to an assertion.
+//
+// Ident and SelectorExpr are included because they print nicely and the variable
+// names may provide additional context to their values.
+// BasicLit and CompositeLit are excluded because their source is equivalent to
+// their value, which is already available.
+// Other types are ignored for now, but could be added if they are relevant.
+func filterArgs(args []ast.Expr) []ast.Expr {
+	result := make([]ast.Expr, len(args))
+	for i, arg := range args {
+		switch arg.(type) {
+		case *ast.Ident, *ast.SelectorExpr:
+			result[i] = arg
+		default:
+			result[i] = nil
+		}
+	}
+	return result
+}
+
+func filterExprExcludeFirst(args []ast.Expr) []ast.Expr {
+	return filterArgs(args[1:])
+}
+
+func filterExprArgsFromComparison(args []ast.Expr) []ast.Expr {
+	if len(args) < 1 {
+		return nil
+	}
+	if callExpr, ok := args[1].(*ast.CallExpr); ok {
+		return filterArgs(callExpr.Args)
+	}
+	return nil
+}

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -46,7 +46,6 @@ func TestGetConditionMultipleCallsOnSameLine(t *testing.T) {
 	msg, err := shimcaller("foo")()
 	assert.NilError(t, err)
 	assert.Assert(t, cmp.EqualMultiLine(`"foo"`, msg))
-
 }
 
 func shimcaller(_ string) func() (string, error) {

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/internal/source"
 )
 
@@ -38,5 +39,18 @@ func TestGetConditionIfStatement(t *testing.T) {
 }
 
 func shim(_, _, _ string) (string, error) {
-	return source.GetCondition(1, 2)
+	return source.FormattedCallExprArg(1, 2)
+}
+
+func TestGetConditionMultipleCallsOnSameLine(t *testing.T) {
+	msg, err := shimcaller("foo")()
+	assert.NilError(t, err)
+	assert.Assert(t, cmp.EqualMultiLine(`"foo"`, msg))
+
+}
+
+func shimcaller(_ string) func() (string, error) {
+	return func() (string, error) {
+		return source.FormattedCallExprArg(1, 0)
+	}
 }

--- a/skip/skip.go
+++ b/skip/skip.go
@@ -72,7 +72,7 @@ func ifCondition(t skipT, condition bool, msgAndArgs ...interface{}) {
 		stackIndex = 2
 		argPos     = 1
 	)
-	source, err := source.GetCondition(stackIndex, argPos)
+	source, err := source.FormattedCallExprArg(stackIndex, argPos)
 	if err != nil {
 		t.Log(err.Error())
 		t.Skip(format.Message(msgAndArgs...))


### PR DESCRIPTION
Currently `Equal` only prints the value and type of its arguments. Since the order of the arguments is ambiguous (`actual, expected` or `expected, actual`) it can be difficult to tell which value is which.

This PR adds includes the literal variable name in the failure message along with the value and type. The variable must be an `ast.Ident` or `ast.SelectorExpr`. This should make tests self-documenting, as most tests will store at least the expected value in a variable, and possible the actual value as well. 

Examples can be seen in `assert_test.go`.

This PR also includes a refactor to `Comparison` to have it always return a `Result`. 