### PR TITLE
Remove cmp.EqualMultiLine, use cmp.Equal

### DIFF
--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -204,6 +204,17 @@ func TestEqualFailureWithCallExprArgument(t *testing.T) {
 		"assertion failed:  (string) != custom error (string)")
 }
 
+func TestAssertFailureWithOfflineComparison(t *testing.T) {
+	fakeT := &fakeTestingT{}
+	a := 1
+	b := 2
+	// store comparison in a variable, so ast lookup can't find it
+	comparison := cmp.Equal(a, b)
+	Assert(fakeT, comparison)
+	// expected value wont have variable names
+	expectFailNowed(t, fakeT, "assertion failed: 1 (int) != 2 (int)")
+}
+
 type testingT interface {
 	Errorf(msg string, args ...interface{})
 	Fatalf(msg string, args ...interface{})

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -64,10 +64,10 @@ func Equal(x, y interface{}) Comparison {
 		}
 		return ResultFailureTemplate(`
 			{{- .Data.x}} (
-				{{- with index .Args 0 }}{{ formatNode . }} {{end -}}
+				{{- with callArg 0 }}{{ formatNode . }} {{end -}}
 				{{- printf "%T" .Data.x -}}
 			) != {{ .Data.y}} (
-				{{- with index .Args 1 }}{{ formatNode . }} {{end -}}
+				{{- with callArg 1 }}{{ formatNode . }} {{end -}}
 				{{- printf "%T" .Data.y -}}
 			)`,
 			map[string]interface{}{"x": x, "y": y})
@@ -96,8 +96,8 @@ func multiLineStringDiffResult(x, y string) Result {
 		return ResultFailure(fmt.Sprintf("failed to diff: %s", err))
 	}
 	return ResultFailureTemplate(`
---- {{ with index .Args 0 }}{{ formatNode . }}{{else}}←{{end}}
-+++ {{ with index .Args 1 }}{{ formatNode . }}{{else}}→{{end}}
+--- {{ with callArg 0 }}{{ formatNode . }}{{else}}←{{end}}
++++ {{ with callArg 1 }}{{ formatNode . }}{{else}}→{{end}}
 {{ .Data.diff }}`,
 		map[string]interface{}{"diff": diff})
 }

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -56,8 +56,11 @@ func toResult(success bool, msg string) Result {
 // Equal succeeds if x == y.
 func Equal(x, y interface{}) Comparison {
 	return func() Result {
-		if x == y {
+		switch {
+		case x == y:
 			return ResultSuccess
+		case isMultiLineStringCompare(x, y):
+			return multiLineStringDiffResult(x.(string), y.(string))
 		}
 		return ResultFailureTemplate(`
 			{{- .Data.x}} (
@@ -69,6 +72,34 @@ func Equal(x, y interface{}) Comparison {
 			)`,
 			map[string]interface{}{"x": x, "y": y})
 	}
+}
+
+func isMultiLineStringCompare(x, y interface{}) bool {
+	strX, ok := x.(string)
+	if !ok {
+		return false
+	}
+	strY, ok := y.(string)
+	if !ok {
+		return false
+	}
+	return strings.Contains(strX, "\n") || strings.Contains(strY, "\n")
+}
+
+func multiLineStringDiffResult(x, y string) Result {
+	diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:       difflib.SplitLines(x),
+		B:       difflib.SplitLines(y),
+		Context: 3,
+	})
+	if err != nil {
+		return ResultFailure(fmt.Sprintf("failed to diff: %s", err))
+	}
+	return ResultFailureTemplate(`
+--- {{ with index .Args 0 }}{{ formatNode . }}{{else}}←{{end}}
++++ {{ with index .Args 1 }}{{ formatNode . }}{{else}}→{{end}}
+{{ .Data.diff }}`,
+		map[string]interface{}{"diff": diff})
 }
 
 // Len succeeds if the sequence has the expected length.
@@ -158,28 +189,6 @@ func Panics(f func()) Comparison {
 		}()
 		f()
 		return ResultFailure("did not panic")
-	}
-}
-
-// EqualMultiLine succeeds if the two strings are equal. If they are not equal
-// the failure message will be the difference between the two strings.
-func EqualMultiLine(x, y string) Comparison {
-	return func() Result {
-		if x == y {
-			return ResultSuccess
-		}
-
-		diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-			A:        difflib.SplitLines(x),
-			B:        difflib.SplitLines(y),
-			FromFile: "left",
-			ToFile:   "right",
-			Context:  3,
-		})
-		if err != nil {
-			return ResultFailure(fmt.Sprintf("failed to produce diff: %s", err))
-		}
-		return ResultFailure("\n" + diff)
 	}
 }
 

--- a/assert/result.go
+++ b/assert/result.go
@@ -30,7 +30,6 @@ func runComparison(
 		args, err := source.CallExprArgs(stackIndex)
 		if err != nil {
 			t.Log(err.Error())
-			// TODO: probably need to not call FailureMessage in this case
 		}
 		message = typed.FailureMessage(filterPrintableExpr(exprFilter(args)))
 	case resultBasic:
@@ -75,6 +74,9 @@ func filterPrintableExpr(args []ast.Expr) []ast.Expr {
 }
 
 func filterExprExcludeFirst(args []ast.Expr) []ast.Expr {
+	if len(args) < 1 {
+		return nil
+	}
 	return args[1:]
 }
 


### PR DESCRIPTION
Remove the extra comparison function, and use difflib to format the failure from `Equal` if  the two args are strings and contain at least one newline character.

Also fail more gracefully if the comparison call args can't be found.