### PR TITLE
Fix a bug in internal/source

### DIFF
--- a/assert/result.go
+++ b/assert/result.go
@@ -30,6 +30,7 @@ func runComparison(
 		args, err := source.CallExprArgs(stackIndex)
 		if err != nil {
 			t.Log(err.Error())
+			// TODO: probably need to not call FailureMessage in this case
 		}
 		message = typed.FailureMessage(filterPrintableExpr(exprFilter(args)))
 	case resultBasic:

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/gotestyourself/gotestyourself/assert"
-	"github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/internal/source"
 )
 
@@ -40,16 +39,4 @@ func TestGetConditionIfStatement(t *testing.T) {
 
 func shim(_, _, _ string) (string, error) {
 	return source.FormattedCallExprArg(1, 2)
-}
-
-func TestGetConditionMultipleCallsOnSameLine(t *testing.T) {
-	msg, err := shimcaller("foo")()
-	assert.NilError(t, err)
-	assert.Assert(t, cmp.EqualMultiLine(`"foo"`, msg))
-}
-
-func shimcaller(_ string) func() (string, error) {
-	return func() (string, error) {
-		return source.FormattedCallExprArg(1, 0)
-	}
 }


### PR DESCRIPTION
An ast.Ident child is not necessary for the CallExpr. I'm not sure why I wrote this test, but the expectation is wrong.

Added some debug to `internal/source` to help debug these failures when they happen.