### PR TITLE
Deprecate asserts in golden/icmd

### DIFF
--- a/assert/cmp/result.go
+++ b/assert/cmp/result.go
@@ -36,6 +36,15 @@ func ResultFailure(message string) Result {
 	return result{message: message}
 }
 
+// ResultFromError returns ResultSuccess if err is nil. Otherwise ResultFailure
+// is returned with the error message as the failure message.
+func ResultFromError(err error) Result {
+	if err == nil {
+		return ResultSuccess
+	}
+	return ResultFailure(err.Error())
+}
+
 type templatedResult struct {
 	success  bool
 	template string

--- a/golden/example_test.go
+++ b/golden/example_test.go
@@ -3,6 +3,7 @@ package golden_test
 import (
 	"testing"
 
+	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/gotestyourself/gotestyourself/golden"
 )
 
@@ -10,6 +11,10 @@ var t = &testing.T{}
 
 func ExampleAssert() {
 	golden.Assert(t, "foo", "foo-content.golden")
+}
+
+func ExampleString() {
+	assert.Assert(t, golden.String("foo", "foo-content.golden"))
 }
 
 func ExampleAssertBytes() {

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -119,3 +119,33 @@ func setupGoldenFile(t *testing.T, content string) (string, func()) {
 		assert.NilError(t, os.Remove(f.Name()))
 	}
 }
+
+func TestStringFailure(t *testing.T) {
+	filename, clean := setupGoldenFile(t, "this is\nthe text")
+	defer clean()
+
+	result := String("this is\nnot the text", filename)()
+	assert.Assert(t, !result.Success())
+	assert.Equal(t, result.(failure).FailureMessage(), `
+--- expected
++++ actual
+@@ -1,2 +1,2 @@
+ this is
+-the text
++not the text
+`)
+}
+
+type failure interface {
+	FailureMessage() string
+}
+
+func TestBytesFailure(t *testing.T) {
+	filename, clean := setupGoldenFile(t, "5556")
+	defer clean()
+
+	result := Bytes([]byte("5555"), filename)()
+	assert.Assert(t, !result.Success())
+	assert.Equal(t, result.(failure).FailureMessage(),
+		`[53 53 53 53] (actual) != [53 53 53 54] (expected)`)
+}

--- a/icmd/command_test.go
+++ b/icmd/command_test.go
@@ -8,21 +8,18 @@ import (
 
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/gotestyourself/gotestyourself/skip"
 )
 
 func TestRunCommandSuccess(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Needs porting to Windows")
-	}
+	skip.If(t, runtime.GOOS == "windows", "ls not available")
 
 	result := RunCommand("ls")
 	result.Assert(t, Success)
 }
 
 func TestRunCommandWithCombined(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Needs porting to Windows")
-	}
+	skip.If(t, runtime.GOOS == "windows", "ls not available")
 
 	result := RunCommand("ls", "-a")
 	result.Assert(t, Expected{})
@@ -32,9 +29,7 @@ func TestRunCommandWithCombined(t *testing.T) {
 }
 
 func TestRunCommandWithTimeoutFinished(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Needs porting to Windows")
-	}
+	skip.If(t, runtime.GOOS == "windows", "ls not available")
 
 	result := RunCmd(Cmd{
 		Command: []string{"ls", "-a"},
@@ -44,9 +39,7 @@ func TestRunCommandWithTimeoutFinished(t *testing.T) {
 }
 
 func TestRunCommandWithTimeoutKilled(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Needs porting to Windows")
-	}
+	skip.If(t, runtime.GOOS == "windows", "sh not available")
 
 	command := []string{"sh", "-c", "while true ; do echo 1 ; sleep .5 ; done"}
 	result := RunCmd(Cmd{Command: command, Timeout: 1250 * time.Millisecond})


### PR DESCRIPTION
Deprecates `golden` and `icmd` Assert and replaces them with `cmp.Comparison` that can be used with `assert.Assert`.

Maybe we don't need to deprecate them. The comparison can still be added so they can be used with Assert/Check.

Previously `icmd.Assert` used `FailNow` (which matches `assert.Assert`), but `golden.Assert` used `Fail`. We should at least make them consistent, and the comparison can be used with `assert.Check`.