### PR TITLE
Remove assert.NilError use assert.Assert

### DIFF
--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -102,24 +102,24 @@ func (e *customError) Error() string {
 	return "custom error"
 }
 
-func TestNilErrorSuccess(t *testing.T) {
+func TestAssertWithNilSuccess(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
 	var err error
-	NilError(fakeT, err)
+	Assert(fakeT, err)
 	expectSuccess(t, fakeT)
 
-	NilError(fakeT, nil)
+	Assert(fakeT, nil)
 	expectSuccess(t, fakeT)
 
 	var customErr *customError
-	NilError(fakeT, customErr)
+	Assert(fakeT, customErr)
 }
 
-func TestNilErrorFailure(t *testing.T) {
+func TestAssertWithErrorFailure(t *testing.T) {
 	fakeT := &fakeTestingT{}
 
-	NilError(fakeT, fmt.Errorf("this is the error"))
+	Assert(fakeT, fmt.Errorf("this is the error"))
 	expectFailNowed(t, fakeT, "assertion failed: error is not nil: this is the error")
 }
 

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -120,19 +120,6 @@ func Len(seq interface{}, expected int) Comparison {
 	}
 }
 
-// NilError succeeds if the last argument is a nil error.
-func NilError(arg interface{}, args ...interface{}) Comparison {
-	return func() Result {
-		msgFunc := func(value reflect.Value) string {
-			return fmt.Sprintf("error is not nil: %+v", value.Interface().(error))
-		}
-		if len(args) == 0 {
-			return isNil(arg, msgFunc)()
-		}
-		return isNil(args[len(args)-1], msgFunc)()
-	}
-}
-
 // Contains succeeds if item is in collection. Collection may be a string, map,
 // slice, or array.
 //
@@ -224,16 +211,9 @@ func ErrorContains(err error, substring string) Comparison {
 
 // Nil succeeds if obj is a nil interface, pointer, or function.
 //
-// Use NilError() for comparing errors. Use Len(obj, 0) for comparing slices,
+// Use assert.Assert() for comparing errors. Use Len(obj, 0) for comparing slices,
 // maps, and channels.
 func Nil(obj interface{}) Comparison {
-	msgFunc := func(value reflect.Value) string {
-		return fmt.Sprintf("%v (type %s) is not nil", reflect.Indirect(value), value.Type())
-	}
-	return isNil(obj, msgFunc)
-}
-
-func isNil(obj interface{}, msgFunc func(reflect.Value) string) Comparison {
 	return func() Result {
 		if obj == nil {
 			return ResultSuccess
@@ -244,7 +224,11 @@ func isNil(obj interface{}, msgFunc func(reflect.Value) string) Comparison {
 			if value.IsNil() {
 				return ResultSuccess
 			}
-			return ResultFailure(msgFunc(value))
+
+			return ResultFailure(fmt.Sprintf(
+				"%v (type %s) is not nil",
+				reflect.Indirect(value),
+				value.Type()))
 		}
 
 		return ResultFailure(fmt.Sprintf("%v (type %s) can not be nil", value, value.Type()))

--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -1,7 +1,6 @@
 package cmp
 
 import (
-	"bytes"
 	"fmt"
 	"go/ast"
 	"io"
@@ -84,35 +83,6 @@ func TestLen(t *testing.T) {
 			}
 		})
 	}
-}
-
-type stubError struct{}
-
-func (e *stubError) Error() string { return "stub error" }
-
-func TestNilError(t *testing.T) {
-	var s *stubError
-	result := NilError(s)()
-	assertSuccess(t, result)
-
-	result = NilError(nil)()
-	assertSuccess(t, result)
-
-	var e error
-	result = NilError(e)()
-	assertSuccess(t, result)
-
-	buf := new(bytes.Buffer)
-	result = NilError(buf.WriteString("ok"))()
-	assertSuccess(t, result)
-
-	s = &stubError{}
-	result = NilError(s)()
-	assertFailure(t, result, "error is not nil: stub error")
-
-	e = &stubError{}
-	result = NilError(e)()
-	assertFailure(t, result, "error is not nil: stub error")
 }
 
 func TestPanics(t *testing.T) {

--- a/env/env.go
+++ b/env/env.go
@@ -22,16 +22,16 @@ func Patch(t assert.TestingT, key, value string) func() {
 		ht.Helper()
 	}
 	oldValue, ok := os.LookupEnv(key)
-	assert.NilError(t, os.Setenv(key, value))
+	assert.Assert(t, os.Setenv(key, value))
 	return func() {
 		if ht, ok := t.(helperT); ok {
 			ht.Helper()
 		}
 		if !ok {
-			assert.NilError(t, os.Unsetenv(key))
+			assert.Assert(t, os.Unsetenv(key))
 			return
 		}
-		assert.NilError(t, os.Setenv(key, oldValue))
+		assert.Assert(t, os.Setenv(key, oldValue))
 	}
 }
 
@@ -45,7 +45,7 @@ func PatchAll(t assert.TestingT, env map[string]string) func() {
 	os.Clearenv()
 
 	for key, value := range env {
-		assert.NilError(t, os.Setenv(key, value))
+		assert.Assert(t, os.Setenv(key, value))
 	}
 	return func() {
 		if ht, ok := t.(helperT); ok {
@@ -53,7 +53,7 @@ func PatchAll(t assert.TestingT, env map[string]string) func() {
 		}
 		os.Clearenv()
 		for key, oldVal := range ToMap(oldEnv) {
-			assert.NilError(t, os.Setenv(key, oldVal))
+			assert.Assert(t, os.Setenv(key, oldVal))
 		}
 	}
 }
@@ -81,12 +81,12 @@ func ChangeWorkingDir(t assert.TestingT, dir string) func() {
 		ht.Helper()
 	}
 	cwd, err := os.Getwd()
-	assert.NilError(t, err)
-	assert.NilError(t, os.Chdir(dir))
+	assert.Assert(t, err)
+	assert.Assert(t, os.Chdir(dir))
 	return func() {
 		if ht, ok := t.(helperT); ok {
 			ht.Helper()
 		}
-		assert.NilError(t, os.Chdir(cwd))
+		assert.Assert(t, os.Chdir(cwd))
 	}
 }

--- a/fs/example_test.go
+++ b/fs/example_test.go
@@ -18,7 +18,7 @@ func ExampleNewDir() {
 	defer dir.Remove()
 
 	files, err := ioutil.ReadDir(dir.Path())
-	assert.NilError(t, err)
+	assert.Assert(t, err)
 	assert.Assert(t, cmp.Len(files, 0))
 }
 
@@ -28,7 +28,7 @@ func ExampleNewFile() {
 	defer file.Remove()
 
 	content, err := ioutil.ReadFile(file.Path())
-	assert.NilError(t, err)
+	assert.Assert(t, err)
 	assert.Equal(t, "content\n", content)
 }
 

--- a/fs/file.go
+++ b/fs/file.go
@@ -38,12 +38,12 @@ func NewFile(t assert.TestingT, prefix string, ops ...PathOp) *File {
 		ht.Helper()
 	}
 	tempfile, err := ioutil.TempFile("", prefix+"-")
-	assert.NilError(t, err)
+	assert.Assert(t, err)
 	file := &File{path: tempfile.Name()}
-	assert.NilError(t, tempfile.Close())
+	assert.Assert(t, tempfile.Close())
 
 	for _, op := range ops {
-		assert.NilError(t, op(file))
+		assert.Assert(t, op(file))
 	}
 	return file
 }
@@ -71,11 +71,11 @@ func NewDir(t assert.TestingT, prefix string, ops ...PathOp) *Dir {
 		ht.Helper()
 	}
 	path, err := ioutil.TempDir("", prefix+"-")
-	assert.NilError(t, err)
+	assert.Assert(t, err)
 	dir := &Dir{path: path}
 
 	for _, op := range ops {
-		assert.NilError(t, op(dir))
+		assert.Assert(t, op(dir))
 	}
 	return dir
 }

--- a/fs/ops_test.go
+++ b/fs/ops_test.go
@@ -19,7 +19,7 @@ func TestFromDir(t *testing.T) {
 
 func assertFileWithContent(t *testing.T, path, content string) {
 	actual, err := ioutil.ReadFile(path)
-	assert.NilError(t, err)
+	assert.Assert(t, err)
 
 	assert.Equal(t, content, string(actual), "file %s", path)
 }

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -29,7 +29,7 @@ func Get(t assert.TestingT, filename string) []byte {
 		ht.Helper()
 	}
 	expected, err := ioutil.ReadFile(Path(filename))
-	assert.NilError(t, err)
+	assert.Assert(t, err)
 	return expected
 }
 
@@ -44,7 +44,7 @@ func Path(filename string) string {
 func update(t assert.TestingT, filename string, actual []byte) {
 	if *flagUpdate {
 		err := ioutil.WriteFile(Path(filename), actual, 0644)
-		assert.NilError(t, err)
+		assert.Assert(t, err)
 	}
 }
 
@@ -70,7 +70,7 @@ func Assert(t assert.TestingT, actual string, filename string, msgAndArgs ...int
 		ToFile:   "Actual",
 		Context:  3,
 	})
-	assert.Assert(t, cmp.NilError(err), msgAndArgs...)
+	assert.Assert(t, err, msgAndArgs...)
 	t.Log(format.WithCustomMessage(fmt.Sprintf("Not Equal: \n%s", diff), msgAndArgs...))
 	t.Fail()
 	return false

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -110,12 +110,12 @@ func setUpdateFlag() func() {
 func setupGoldenFile(t *testing.T, content string) (string, func()) {
 	_ = os.Mkdir("testdata", 0755)
 	f, err := ioutil.TempFile("testdata", "")
-	assert.Assert(t, cmp.NilError(err), "fail to setup test golden file")
+	assert.Assert(t, err, "fail to setup test golden file")
 	err = ioutil.WriteFile(f.Name(), []byte(content), 0660)
-	assert.Assert(t, cmp.NilError(err), "fail to write test golden file with %q", content)
+	assert.Assert(t, err, "fail to write test golden file with %q", content)
 	_, name := filepath.Split(f.Name())
 	t.Log(f.Name(), name)
 	return name, func() {
-		assert.NilError(t, os.Remove(f.Name()))
+		assert.Assert(t, os.Remove(f.Name()))
 	}
 }

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGetConditionSingleLine(t *testing.T) {
 	msg, err := shim("not", "this", "this text")
-	assert.NilError(t, err)
+	assert.Assert(t, err)
 	assert.Equal(t, `"this text"`, msg)
 }
 
@@ -22,7 +22,7 @@ func TestGetConditionMultiLine(t *testing.T) {
 		"second",
 		"this text",
 	)
-	assert.NilError(t, err)
+	assert.Assert(t, err)
 	assert.Equal(t, `"this text"`, msg)
 }
 
@@ -32,7 +32,7 @@ func TestGetConditionIfStatement(t *testing.T) {
 		"second",
 		"this text",
 	); true {
-		assert.NilError(t, err)
+		assert.Assert(t, err)
 		assert.Equal(t, `"this text"`, msg)
 	}
 }

--- a/testsum/scan_test.go
+++ b/testsum/scan_test.go
@@ -45,7 +45,7 @@ ok      github.com/gotestyourself/gotestyourself/icmd   1.256s
 
 	out := new(bytes.Buffer)
 	summary, err := Scan(strings.NewReader(source), out)
-	assert.NilError(t, err)
+	assert.Assert(t, err)
 	assert.Check(t, summary.Elapsed != 0)
 	assert.Check(t, is.DeepEqual(&Summary{Total: 8, Skipped: 1}, summary, cmpSummary))
 	assert.Equal(t, source, out.String())
@@ -70,7 +70,7 @@ FAIL    github.com/gotestyourself/gotestyourself/testsum        0.002s
 
 	out := new(bytes.Buffer)
 	summary, err := Scan(strings.NewReader(source), out)
-	assert.NilError(t, err)
+	assert.Assert(t, err)
 	assert.Check(t, summary.Elapsed != 0)
 	assert.Check(t, is.Equal(source, out.String()))
 
@@ -103,7 +103,7 @@ PASS
 `
 
 	summary, err := Scan(strings.NewReader(source), ioutil.Discard)
-	assert.NilError(t, err)
+	assert.Assert(t, err)
 	assert.Check(t, summary.Elapsed != 0)
 
 	expected := &Summary{Total: 1}
@@ -130,7 +130,7 @@ exit status 1
 `
 
 	summary, err := Scan(strings.NewReader(source), ioutil.Discard)
-	assert.NilError(t, err)
+	assert.Assert(t, err)
 	assert.Check(t, summary.Elapsed != 0)
 
 	expectedOutput := `=== RUN   TestNested/a


### PR DESCRIPTION
I noticed that the old `Comparison` interface was basically `error`, so this is an experiment to see if it makes sense to remove `NilError` and just use `Assert` directly. The error message is unchanged.