### PR TITLE
Support error as a value for Comparison

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -76,7 +76,7 @@ import (
 	"github.com/gotestyourself/gotestyourself/internal/source"
 )
 
-// BoolOrComparison can be a bool, or cmp.Comparison. Other types will panic.
+// BoolOrComparison can be a bool, or cmp.Comparison. See Assert() for usage.
 type BoolOrComparison interface{}
 
 // TestingT is the subset of testing.T used by the assert package.
@@ -203,11 +203,14 @@ func boolFailureMessage(expr ast.Expr) (string, error) {
 // Assert performs a comparison. If the comparison fails the test is marked as
 // failed, a failure message is logged, and execution is stopped immediately.
 //
-// The comparison argument may be one of two types: bool or cmp.Comparison.
+// The comparison argument may be one of three types: bool, cmp.Comparison or
+// error.
 // When called with a bool the failure message will contain the literal source
 // code of the expression.
 // When called with a cmp.Comparison the comparison is responsible for producing
 // a helpful failure message.
+// When called with an error a nil value is considered success. A non-nil error
+// is a failure, and Error() is used as the failure message.
 func Assert(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
@@ -227,13 +230,13 @@ func Check(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) b
 	return assert(t, t.Fail, filterExprArgsFromComparison, comparison, msgAndArgs...)
 }
 
-// NilError fails the test immediately if the last arg is a non-nil error.
-// This is equivalent to Assert(t, cmp.NilError(err)).
+// NilError fails the test immediately if err is not nil.
+// This is equivalent to Assert(t, err)
 func NilError(t TestingT, err error, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	assert(t, t.FailNow, filterExprExcludeFirst, cmp.NilError(err), msgAndArgs...)
+	assert(t, t.FailNow, filterExprExcludeFirst, err, msgAndArgs...)
 }
 
 // Equal uses the == operator to assert two values are equal and fails the test

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -92,6 +92,7 @@ type helperT interface {
 
 const failureMessage = "assertion failed: "
 
+// nolint: gocyclo
 func assert(
 	t TestingT,
 	failer func(),
@@ -114,6 +115,13 @@ func assert(
 	case func() (success bool, message string):
 		success = runCompareFunc(t, check, msgAndArgs...)
 
+	case nil:
+		return true
+
+	case error:
+		msg := "error is not nil: "
+		t.Log(format.WithCustomMessage(failureMessage+msg+check.Error(), msgAndArgs...))
+
 	case cmp.Comparison:
 		success = runComparison(t, argsFilter, check, msgAndArgs...)
 
@@ -121,7 +129,7 @@ func assert(
 		success = runComparison(t, argsFilter, check, msgAndArgs...)
 
 	default:
-		panic(fmt.Sprintf("comparison arg must be bool or Comparison, not %T", comparison))
+		t.Log(fmt.Sprintf("invalid Comparison: %v (%T)", check, check))
 	}
 
 	if success {

--- a/assert/cmp/compare.go
+++ b/assert/cmp/compare.go
@@ -120,19 +120,6 @@ func Len(seq interface{}, expected int) Comparison {
 	}
 }
 
-// NilError succeeds if the last argument is a nil error.
-func NilError(arg interface{}, args ...interface{}) Comparison {
-	return func() Result {
-		msgFunc := func(value reflect.Value) string {
-			return fmt.Sprintf("error is not nil: %+v", value.Interface().(error))
-		}
-		if len(args) == 0 {
-			return isNil(arg, msgFunc)()
-		}
-		return isNil(args[len(args)-1], msgFunc)()
-	}
-}
-
 // Contains succeeds if item is in collection. Collection may be a string, map,
 // slice, or array.
 //

--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -1,7 +1,6 @@
 package cmp
 
 import (
-	"bytes"
 	"fmt"
 	"go/ast"
 	"io"
@@ -84,35 +83,6 @@ func TestLen(t *testing.T) {
 			}
 		})
 	}
-}
-
-type stubError struct{}
-
-func (e *stubError) Error() string { return "stub error" }
-
-func TestNilError(t *testing.T) {
-	var s *stubError
-	result := NilError(s)()
-	assertSuccess(t, result)
-
-	result = NilError(nil)()
-	assertSuccess(t, result)
-
-	var e error
-	result = NilError(e)()
-	assertSuccess(t, result)
-
-	buf := new(bytes.Buffer)
-	result = NilError(buf.WriteString("ok"))()
-	assertSuccess(t, result)
-
-	s = &stubError{}
-	result = NilError(s)()
-	assertFailure(t, result, "error is not nil: stub error")
-
-	e = &stubError{}
-	result = NilError(e)()
-	assertFailure(t, result, "error is not nil: stub error")
 }
 
 func TestPanics(t *testing.T) {

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -70,7 +70,7 @@ func Assert(t assert.TestingT, actual string, filename string, msgAndArgs ...int
 		ToFile:   "Actual",
 		Context:  3,
 	})
-	assert.Assert(t, cmp.NilError(err), msgAndArgs...)
+	assert.NilError(t, err, msgAndArgs...)
 	t.Log(format.WithCustomMessage(fmt.Sprintf("Not Equal: \n%s", diff), msgAndArgs...))
 	t.Fail()
 	return false

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -110,9 +110,9 @@ func setUpdateFlag() func() {
 func setupGoldenFile(t *testing.T, content string) (string, func()) {
 	_ = os.Mkdir("testdata", 0755)
 	f, err := ioutil.TempFile("testdata", "")
-	assert.Assert(t, cmp.NilError(err), "fail to setup test golden file")
+	assert.Assert(t, err, "fail to setup test golden file")
 	err = ioutil.WriteFile(f.Name(), []byte(content), 0660)
-	assert.Assert(t, cmp.NilError(err), "fail to write test golden file with %q", content)
+	assert.Assert(t, err, "fail to write test golden file with %q", content)
 	_, name := filepath.Split(f.Name())
 	t.Log(f.Name(), name)
 	return name, func() {


### PR DESCRIPTION
Alternative to #54 

Instead of removing `NilError`, keep it around, but still support `nil/error` in `Assert/Check` so that Comparisons can be created from any function that returns `error`.

Also fail instead of panic in the default case.