### PR TITLE
Add DeepEqual top level assertion

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -37,10 +37,10 @@ The example below shows assert used with some common types.
 	    assert.Assert(t, os.IsNotExist(err), "got %+v", err)
 
 	    // complex types
+	    assert.DeepEqual(t, result, myStruct{Name: "title"})
 	    assert.Assert(t, is.Len(items, 3))
 	    assert.Assert(t, len(sequence) != 0) // NotEmpty
 	    assert.Assert(t, is.Contains(mapping, "key"))
-	    assert.Assert(t, is.DeepEqual(result, myStruct{Name: "title"}))
 
 	    // pointers and interface
 	    assert.Assert(t, is.Nil(ref))
@@ -71,6 +71,7 @@ import (
 	"go/ast"
 	"go/token"
 
+	gocmp "github.com/google/go-cmp/cmp"
 	"github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/internal/format"
 	"github.com/gotestyourself/gotestyourself/internal/source"
@@ -246,4 +247,14 @@ func Equal(t TestingT, x, y interface{}, msgAndArgs ...interface{}) {
 		ht.Helper()
 	}
 	assert(t, t.FailNow, filterExprExcludeFirst, cmp.Equal(x, y), msgAndArgs...)
+}
+
+// DeepEqual uses https://github.com/google/go-cmp/cmp to assert two values
+// are equal and fails the test if they are not equal.
+// This is equivalent to Assert(t, cmp.DeepEqual(x, y)).
+func DeepEqual(t TestingT, x, y interface{}, opts ...gocmp.Option) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	assert(t, t.FailNow, filterExprExcludeFirst, cmp.DeepEqual(x, y, opts...))
 }

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	gocmp "github.com/google/go-cmp/cmp"
 	"github.com/gotestyourself/gotestyourself/assert/cmp"
 )
 
@@ -278,4 +279,31 @@ func expectSuccess(t testingT, fakeT *fakeTestingT) {
 	if fakeT.failed {
 		t.Errorf("should not have failed, got messages %s", fakeT.msgs)
 	}
+}
+
+type stub struct {
+	a string
+	b int
+}
+
+func TestDeepEqualSuccess(t *testing.T) {
+	actual := stub{"ok", 1}
+	expected := stub{"ok", 1}
+
+	fakeT := &fakeTestingT{}
+	DeepEqual(fakeT, actual, expected, gocmp.AllowUnexported(stub{}))
+	expectSuccess(t, fakeT)
+}
+
+func TestDeepEqualFailure(t *testing.T) {
+	actual := stub{"ok", 1}
+	expected := stub{"ok", 2}
+
+	fakeT := &fakeTestingT{}
+	DeepEqual(fakeT, actual, expected, gocmp.AllowUnexported(stub{}))
+	expectFailNowed(t, fakeT, "assertion failed: "+`
+{assert.stub}.b:
+	-: 1
+	+: 2
+`)
 }


### PR DESCRIPTION
It's hard to tell exactly how common this assertion will be, because it's part of `testify/assert.Equal`, but I imagine it will be common enough that it should be at the top level.