### PR TITLE
Add cmp.ErrorType

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -34,7 +34,7 @@ The example below shows assert used with some common types.
 	    assert.NilError(t, closer.Close())
 	    assert.Assert(t, is.Error(err, "the exact error message"))
 	    assert.Assert(t, is.ErrorContains(err, "includes this"))
-	    assert.Assert(t, os.IsNotExist(err), "got %+v", err)
+	    assert.Assert(t, is.ErrorType(err, os.IsNotExist))
 
 	    // complex types
 	    assert.DeepEqual(t, result, myStruct{Name: "title"})


### PR DESCRIPTION
For comparing errors to a type.

I'm thinking with this addition we could add all 3 error funcs (Error, ErrorContains, and ErrorType) as top level convenience functions in `assert`.