### PR TITLE
Improve example / small cleanup

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,5 +13,5 @@
 
 [[constraint]]
   name = "github.com/google/go-cmp"
-  version = "0.1.0"
+  version = "0.2.0"
 

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -51,17 +51,7 @@ Comparisons
 
 https://godoc.org/github.com/gotestyourself/gotestyourself/assert/cmp provides
 many common comparisons. Additional comparisons can be written to compare
-values in other ways.
-
-Below is an example of a custom comparison using a regex pattern:
-
-	func RegexP(value string, pattern string) func() (bool, string) {
-	    return func() (bool, string) {
-	        re := regexp.MustCompile(pattern)
-	        msg := fmt.Sprintf("%q did not match pattern %q", value, pattern)
-	        return re.MatchString(value), msg
-	    }
-	}
+values in other ways. See the example Assert (CustomComparison).
 
 */
 package assert

--- a/assert/cmp/compare_test.go
+++ b/assert/cmp/compare_test.go
@@ -13,15 +13,20 @@ import (
 )
 
 func TestDeepEqual(t *testing.T) {
-	result := DeepEqual([]string{"a", "b"}, []string{"b", "a"})()
-	assertFailure(t, result, `
-{[]string}:
-	-: []string{"a", "b"}
-	+: []string{"b", "a"}
-`)
 
-	result = DeepEqual([]string{"a"}, []string{"a"})()
-	assertSuccess(t, result)
+	actual := DeepEqual([]string{"a", "b"}, []string{"b", "a"})()
+	expected := `
+{[]string}[0]:
+	-: "a"
+	+: "b"
+{[]string}[1]:
+	-: "b"
+	+: "a"
+`
+	assertFailure(t, actual, expected)
+
+	actual = DeepEqual([]string{"a"}, []string{"a"})()
+	assertSuccess(t, actual)
 }
 
 type Stub struct {

--- a/assert/example_test.go
+++ b/assert/example_test.go
@@ -1,0 +1,26 @@
+package assert_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/assert/cmp"
+)
+
+var t = &testing.T{}
+
+func ExampleAssert_customComparison() {
+	regexPattern := func(value string, pattern string) cmp.Comparison {
+		return func() cmp.Result {
+			re := regexp.MustCompile(pattern)
+			if re.MatchString(value) {
+				return cmp.ResultSuccess
+			}
+			return cmp.ResultFailure(
+				fmt.Sprintf("%q did not match pattern %q", value, pattern))
+		}
+	}
+	assert.Assert(t, regexPattern("12345.34", `\d+.\d\d`))
+}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -68,11 +68,13 @@ func (v *scanToLineVisitor) Visit(node ast.Node) ast.Visitor {
 // In golang 1.9 the line number changed from being the line where the statement
 // ended to the line where the statement began.
 func (v *scanToLineVisitor) nodePosition(node ast.Node) token.Position {
-	if isGOVersionBefore19() {
+	if goVersionBefore19 {
 		return v.fileset.Position(node.End())
 	}
 	return v.fileset.Position(node.Pos())
 }
+
+var goVersionBefore19 = isGOVersionBefore19()
 
 func isGOVersionBefore19() bool {
 	version := runtime.Version()


### PR DESCRIPTION
* fix the example of a custom Comparison (it was using the old `func() (string, error)`), and make it a real godoc example.
* only parse go version one instead of on each failure
* `go-cmp` changed diff output after v0.1 so this test will fail after they tag a new release. Fix the test to accept either version for now. We can remove the v0.1 expected after they tag a release.