### PR TITLE
Default to go1.10

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: "Unit Test GO 1.9"
-          command: scripts/ci/test
+          command: scripts/ci/test 1.9-alpine
 
   test-golang-1.8:
     working_directory: /work
@@ -48,7 +48,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: "Unit Test GO 1.8"
-          command: scripts/ci/test 1.8.3-alpine
+          command: scripts/ci/test 1.8-alpine
 
   test-golang-1.10:
     working_directory: /work
@@ -58,7 +58,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: "Unit Test GO 1.10"
-          command: scripts/ci/test 1.10rc2-alpine
+          command: scripts/ci/test 1.10-alpine
 
 workflows:
   version: 2

--- a/dobifiles/Dockerfile
+++ b/dobifiles/Dockerfile
@@ -1,5 +1,5 @@
 ARG     GOLANG_VERSION
-FROM    golang:${GOLANG_VERSION:-1.9.2-alpine}
+FROM    golang:${GOLANG_VERSION:-1.10-alpine}
 
 RUN     apk add -U curl git bash
 

--- a/dobifiles/Dockerfile.lint
+++ b/dobifiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.9-alpine
+FROM    golang:1.10-alpine
 
 RUN     apk add -U git
 


### PR DESCRIPTION
Use minor versions for docker images so that patch releases will be
picked up automatically