### PR TITLE
package x/subtest

### DIFF
--- a/fs/file.go
+++ b/fs/file.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/x/subtest"
 )
 
 // Path objects return their filesystem path. Both File and Dir implement Path.
@@ -45,6 +46,9 @@ func NewFile(t assert.TestingT, prefix string, ops ...PathOp) *File {
 	for _, op := range ops {
 		assert.NilError(t, op(file))
 	}
+	if tc, ok := t.(subtest.TestContext); ok {
+		tc.AddCleanup(file.Remove)
+	}
 	return file
 }
 
@@ -76,6 +80,9 @@ func NewDir(t assert.TestingT, prefix string, ops ...PathOp) *Dir {
 
 	for _, op := range ops {
 		assert.NilError(t, op(dir))
+	}
+	if tc, ok := t.(subtest.TestContext); ok {
+		tc.AddCleanup(dir.Remove)
 	}
 	return dir
 }

--- a/icmd/command.go
+++ b/icmd/command.go
@@ -228,6 +228,7 @@ func StartCmd(cmd Cmd) *Result {
 	return result
 }
 
+// TODO: support exec.CommandContext
 func buildCmd(cmd Cmd) *Result {
 	var execCmd *exec.Cmd
 	switch len(cmd.Command) {

--- a/x/doc.go
+++ b/x/doc.go
@@ -1,0 +1,5 @@
+/*Package x is a namespace for other packages. Packages under x have looser
+compatibility requirements. Packages in this namespace may contain backwards
+incompatible changes within the same major version.
+*/
+package x

--- a/x/subtest/context.go
+++ b/x/subtest/context.go
@@ -1,0 +1,81 @@
+/*Package subtest provides a TestContext to subtests which handles cleanup, and
+provides a testing.TB, and context.Context.
+
+This package was inspired by github.com/frankban/quicktest.
+*/
+package subtest
+
+import (
+	"context"
+	"testing"
+)
+
+type testcase struct {
+	testing.TB
+	ctx          context.Context
+	cleanupFuncs []cleanupFunc
+}
+
+type cleanupFunc func()
+
+func (tc *testcase) Ctx() context.Context {
+	if tc.ctx == nil {
+		var cancel func()
+		tc.ctx, cancel = context.WithCancel(context.Background())
+		tc.AddCleanup(cancel)
+	}
+	return tc.ctx
+}
+
+// Cleanup runs all cleanup functions. Functions are run in the opposite order
+// in which they were added. Cleanup is called automatically before Run exits.
+func (tc *testcase) Cleanup() {
+	for _, f := range tc.cleanupFuncs {
+		// Defer all cleanup functions so they all run even if one calls
+		// t.FailNow() or panics. Deferring them also runs them in reverse order.
+		defer f()
+	}
+	tc.cleanupFuncs = nil
+}
+
+func (tc *testcase) AddCleanup(f func()) {
+	tc.cleanupFuncs = append(tc.cleanupFuncs, f)
+}
+
+func (tc *testcase) Parallel() {
+	tp, ok := tc.TB.(parallel)
+	if !ok {
+		panic("Parallel called with a testing.B")
+	}
+	tp.Parallel()
+}
+
+type parallel interface {
+	Parallel()
+}
+
+// Run a subtest. When subtest exits, every cleanup function added with
+// TestContext.AddCleanup will be run.
+func Run(t *testing.T, name string, subtest func(t TestContext)) bool {
+	return t.Run(name, func(t *testing.T) {
+		tc := &testcase{TB: t}
+		defer tc.Cleanup()
+		subtest(tc)
+	})
+}
+
+// TestContext provides a testing.TB and a context.Context for a test case.
+type TestContext interface {
+	testing.TB
+	// AddCleanup function which will be run when before Run returns.
+	AddCleanup(f func())
+	// Ctx returns a context for the test case. Multiple calls from the same subtest
+	// will return the same context. The context is cancelled when Run
+	// returns.
+	Ctx() context.Context
+	// Parallel calls t.Parallel on the testing.TB. Panics if testing.TB does
+	// not implement Parallel.
+	Parallel()
+}
+
+var _ TestContext = &testcase{}

--- a/x/subtest/context_test.go
+++ b/x/subtest/context_test.go
@@ -1,0 +1,22 @@
+package subtest
+
+import (
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/assert"
+)
+
+func TestRunCallsCleanup(t *testing.T) {
+	calls := []int{}
+	Run(t, "test-run-cleanup", func(t TestContext) {
+		cleanup := func(n int) func() {
+			return func() {
+				calls = append(calls, n)
+			}
+		}
+		t.AddCleanup(cleanup(2))
+		t.AddCleanup(cleanup(1))
+		t.AddCleanup(cleanup(0))
+	})
+	assert.DeepEqual(t, calls, []int{0, 1, 2})
+}

--- a/x/subtest/example_test.go
+++ b/x/subtest/example_test.go
@@ -1,0 +1,67 @@
+package subtest_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/x/subtest"
+)
+
+var t = &testing.T{}
+
+func ExampleRun_tableTest() {
+	var testcases = []struct {
+		data     io.Reader
+		expected int
+	}{
+		{
+			data:     strings.NewReader("invalid input"),
+			expected: 400,
+		},
+		{
+			data:     strings.NewReader("valid input"),
+			expected: 200,
+		},
+	}
+
+	for _, tc := range testcases {
+		subtest.Run(t, "test-service-call", func(t subtest.TestContext) {
+			// startFakeService can shutdown using t.AddCleanup
+			url := startFakeService(t)
+
+			req, err := http.NewRequest("POST", url, tc.data)
+			assert.NilError(t, err)
+			req = req.WithContext(t.Ctx())
+
+			client := newClient(t)
+			resp, err := client.Do(req)
+			assert.NilError(t, err)
+			assert.Equal(t, resp.StatusCode, tc.expected)
+		})
+	}
+}
+
+func startFakeService(t subtest.TestContext) string {
+	// t.AddCleanup(shutdown)
+	return "url"
+}
+
+func newClient(T subtest.TestContext) *http.Client {
+	return &http.Client{}
+}
+
+func ExampleRun_testSuite() {
+	// do suite setup before subtests
+
+	subtest.Run(t, "test-one", func(t subtest.TestContext) {
+		assert.Equal(t, 1, 1)
+	})
+	subtest.Run(t, "test-two", func(t subtest.TestContext) {
+		assert.Equal(t, 2, 2)
+	})
+
+	// do suite teardown after subtests
+}


### PR DESCRIPTION
This `subtest` package makes it easier to automatically cleanup things from helpers by calling `AddCleanup` instead of the helper returning a `func()` to defer. 

The `Ctx` also reduces the number of args we pass around to every helper. Ex: in moby/moby integration we seem to need `t, ctx, client` in most helpers. This gets us down to just `t, client`.

I've put this into `x/subtest` for now because I'm not sure how useful this is yet.