### PR TITLE
Handle windows for `golden` package

### DIFF
--- a/golden/golden.go
+++ b/golden/golden.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/gotestyourself/gotestyourself/assert/cmp"
@@ -41,14 +40,21 @@ func Path(filename string) string {
 	return filepath.Join("testdata", filename)
 }
 
-func update(filename string, actual []byte, clean bool) error {
+func update(filename string, actual []byte, normalize normalize) error {
 	if *flagUpdate {
-		if clean {
-			actual = bytes.Replace(actual, []byte("\r\n"), []byte("\n"), -1)
-		}
-		return ioutil.WriteFile(Path(filename), actual, 0644)
+		return ioutil.WriteFile(Path(filename), normalize(actual), 0644)
 	}
 	return nil
+}
+
+type normalize func([]byte) []byte
+
+func removeCarriageReturn(in []byte) []byte {
+	return bytes.Replace(in, []byte("\r\n"), []byte("\n"), -1)
+}
+
+func exactBytes(in []byte) []byte {
+	return in
 }
 
 // Assert compares the actual content to the expected content in the golden file.
@@ -65,21 +71,28 @@ func Assert(t assert.TestingT, actual string, filename string, msgAndArgs ...int
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	actual = strings.Replace(actual, "\r\n", "\n", -1)
 	return assert.Check(t, String(actual, filename), msgAndArgs...)
 }
 
 // String compares actual to the contents of filename and returns success
 // if the strings are equal.
+// If the `-test.update-golden` flag is set then the actual content is written
+// to the golden file.
+//
+// Any \r\n substrings in actual are converted to a single \n character
+// before comparing it to the expected string. When updating the golden file the
+// normalized version will be written to the file. This allows Windows to use
+// the same golden files as other operating systems.
 func String(actual string, filename string) cmp.Comparison {
 	return func() cmp.Result {
-		result, expected := compare([]byte(actual), filename, true)
+		actualBytes := removeCarriageReturn([]byte(actual))
+		result, expected := compare(actualBytes, filename, removeCarriageReturn)
 		if result != nil {
 			return result
 		}
 		diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
 			A:        difflib.SplitLines(string(expected)),
-			B:        difflib.SplitLines(actual),
+			B:        difflib.SplitLines(string(actualBytes)),
 			FromFile: "expected",
 			ToFile:   "actual",
 			Context:  3,
@@ -115,9 +128,11 @@ func AssertBytes(
 
 // Bytes compares actual to the contents of filename and returns success
 // if the bytes are equal.
+// If the `-test.update-golden` flag is set then the actual content is written
+// to the golden file.
 func Bytes(actual []byte, filename string) cmp.Comparison {
 	return func() cmp.Result {
-		result, expected := compare(actual, filename, false)
+		result, expected := compare(actual, filename, exactBytes)
 		if result != nil {
 			return result
 		}
@@ -126,8 +141,8 @@ func Bytes(actual []byte, filename string) cmp.Comparison {
 	}
 }
 
-func compare(actual []byte, filename string, clean bool) (cmp.Result, []byte) {
-	if err := update(filename, actual, clean); err != nil {
+func compare(actual []byte, filename string, normalize normalize) (cmp.Result, []byte) {
+	if err := update(filename, actual, normalize); err != nil {
 		return cmp.ResultFromError(err), nil
 	}
 	expected, err := ioutil.ReadFile(Path(filename))

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -90,13 +90,13 @@ func TestGoldenAssert(t *testing.T) {
 	assert.Assert(t, success)
 }
 
-func TestGoldenAssertWindows(t *testing.T) {
-	filename, clean := setupGoldenFile(t, "foo\nbar\n")
+func TestGoldenAssertWithCarriageReturnInActual(t *testing.T) {
+	filename, clean := setupGoldenFile(t, "a\rfoo\nbar\n")
 	defer clean()
 
 	fakeT := new(fakeT)
 
-	success := Assert(fakeT, "foo\r\nbar\r\n", filename)
+	success := Assert(fakeT, "a\rfoo\r\nbar\r\n", filename)
 	assert.Assert(t, !fakeT.Failed)
 	assert.Assert(t, success)
 }

--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -90,6 +90,17 @@ func TestGoldenAssert(t *testing.T) {
 	assert.Assert(t, success)
 }
 
+func TestGoldenAssertWindows(t *testing.T) {
+	filename, clean := setupGoldenFile(t, "foo\nbar\n")
+	defer clean()
+
+	fakeT := new(fakeT)
+
+	success := Assert(fakeT, "foo\r\nbar\r\n", filename)
+	assert.Assert(t, !fakeT.Failed)
+	assert.Assert(t, success)
+}
+
 func TestGoldenAssertBytes(t *testing.T) {
 	filename, clean := setupGoldenFile(t, "foo")
 	defer clean()


### PR DESCRIPTION
Always replace `\r` to nothing when comparing the content
and the actual value

Signed-off-by: Vincent Demeester <vincent@sbr.pm>