### PR TITLE
Improve ast expr list naming

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -32,9 +32,9 @@ The example below shows assert used with some common types.
 
 	    // errors
 	    assert.NilError(t, closer.Close())
-	    assert.Assert(t, is.Error(err, "the exact error message"))
-	    assert.Assert(t, is.ErrorContains(err, "includes this"))
-	    assert.Assert(t, is.ErrorType(err, os.IsNotExist))
+	    assert.Error(t, err, "the exact error message")
+	    assert.ErrorContains(t, err, "includes this")
+	    assert.ErrorType(t, err, os.IsNotExist)
 
 	    // complex types
 	    assert.DeepEqual(t, result, myStruct{Name: "title"})
@@ -250,4 +250,40 @@ func DeepEqual(t TestingT, x, y interface{}, opts ...gocmp.Option) {
 		ht.Helper()
 	}
 	assert(t, t.FailNow, filterExprExcludeFirst, cmp.DeepEqual(x, y, opts...))
+}
+
+// Error fails the test if err is nil, or the error message is not the expected
+// message.
+// Equivalent to Assert(t, cmp.Error(err, message)).
+func Error(t TestingT, err error, message string, msgAndArgs ...interface{}) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	assert(t, t.FailNow, filterExprExcludeFirst, cmp.Error(err, message), msgAndArgs...)
+}
+
+// ErrorContains fails the test if err is nil, or the error message does not
+// contain the expected substring.
+// Equivalent to Assert(t, cmp.ErrorContains(err, substring)).
+func ErrorContains(t TestingT, err error, substring string, msgAndArgs ...interface{}) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	assert(t, t.FailNow, filterExprExcludeFirst, cmp.ErrorContains(err, substring), msgAndArgs...)
+}
+
+// ErrorType fails the test if err is nil, or err is not the expected type.
+//
+// Expected can be one of:
+// a func(error) bool which returns true if the error is the expected type,
+// an instance of a struct of the expected type,
+// a pointer to an interface the error is expected to implement,
+// a reflect.Type of the expected struct or interface.
+//
+// Equivalent to Assert(t, cmp.ErrorType(err, expected)).
+func ErrorType(t TestingT, err error, expected interface{}, msgAndArgs ...interface{}) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	assert(t, t.FailNow, filterExprExcludeFirst, cmp.ErrorType(err, expected), msgAndArgs...)
 }

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -87,7 +87,7 @@ const failureMessage = "assertion failed: "
 func assert(
 	t TestingT,
 	failer func(),
-	argsFilter astExprListFilter,
+	argSelector argSelector,
 	comparison BoolOrComparison,
 	msgAndArgs ...interface{},
 ) bool {
@@ -114,10 +114,10 @@ func assert(
 		t.Log(format.WithCustomMessage(failureMessage+msg+check.Error(), msgAndArgs...))
 
 	case cmp.Comparison:
-		success = runComparison(t, argsFilter, check, msgAndArgs...)
+		success = runComparison(t, argSelector, check, msgAndArgs...)
 
 	case func() cmp.Result:
-		success = runComparison(t, argsFilter, check, msgAndArgs...)
+		success = runComparison(t, argSelector, check, msgAndArgs...)
 
 	default:
 		t.Log(fmt.Sprintf("invalid Comparison: %v (%T)", check, check))
@@ -209,7 +209,7 @@ func Assert(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) 
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	assert(t, t.FailNow, filterExprArgsFromComparison, comparison, msgAndArgs...)
+	assert(t, t.FailNow, argsFromComparisonCall, comparison, msgAndArgs...)
 }
 
 // Check performs a comparison. If the comparison fails the test is marked as
@@ -221,7 +221,7 @@ func Check(t TestingT, comparison BoolOrComparison, msgAndArgs ...interface{}) b
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	return assert(t, t.Fail, filterExprArgsFromComparison, comparison, msgAndArgs...)
+	return assert(t, t.Fail, argsFromComparisonCall, comparison, msgAndArgs...)
 }
 
 // NilError fails the test immediately if err is not nil.
@@ -230,7 +230,7 @@ func NilError(t TestingT, err error, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	assert(t, t.FailNow, filterExprExcludeFirst, err, msgAndArgs...)
+	assert(t, t.FailNow, argsAfterT, err, msgAndArgs...)
 }
 
 // Equal uses the == operator to assert two values are equal and fails the test
@@ -239,7 +239,7 @@ func Equal(t TestingT, x, y interface{}, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	assert(t, t.FailNow, filterExprExcludeFirst, cmp.Equal(x, y), msgAndArgs...)
+	assert(t, t.FailNow, argsAfterT, cmp.Equal(x, y), msgAndArgs...)
 }
 
 // DeepEqual uses https://github.com/google/go-cmp/cmp to assert two values
@@ -249,7 +249,7 @@ func DeepEqual(t TestingT, x, y interface{}, opts ...gocmp.Option) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	assert(t, t.FailNow, filterExprExcludeFirst, cmp.DeepEqual(x, y, opts...))
+	assert(t, t.FailNow, argsAfterT, cmp.DeepEqual(x, y, opts...))
 }
 
 // Error fails the test if err is nil, or the error message is not the expected
@@ -259,7 +259,7 @@ func Error(t TestingT, err error, message string, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	assert(t, t.FailNow, filterExprExcludeFirst, cmp.Error(err, message), msgAndArgs...)
+	assert(t, t.FailNow, argsAfterT, cmp.Error(err, message), msgAndArgs...)
 }
 
 // ErrorContains fails the test if err is nil, or the error message does not
@@ -269,7 +269,7 @@ func ErrorContains(t TestingT, err error, substring string, msgAndArgs ...interf
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	assert(t, t.FailNow, filterExprExcludeFirst, cmp.ErrorContains(err, substring), msgAndArgs...)
+	assert(t, t.FailNow, argsAfterT, cmp.ErrorContains(err, substring), msgAndArgs...)
 }
 
 // ErrorType fails the test if err is nil, or err is not the expected type.
@@ -285,5 +285,5 @@ func ErrorType(t TestingT, err error, expected interface{}, msgAndArgs ...interf
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()
 	}
-	assert(t, t.FailNow, filterExprExcludeFirst, cmp.ErrorType(err, expected), msgAndArgs...)
+	assert(t, t.FailNow, argsAfterT, cmp.ErrorType(err, expected), msgAndArgs...)
 }

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -2,6 +2,7 @@ package assert
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	gocmp "github.com/google/go-cmp/cmp"
@@ -306,4 +307,58 @@ func TestDeepEqualFailure(t *testing.T) {
 	-: 1
 	+: 2
 `)
+}
+
+func TestErrorFailure(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		fakeT := &fakeTestingT{}
+
+		var err error
+		Error(fakeT, err, "this error")
+		expectFailNowed(t, fakeT, "assertion failed: expected an error, got nil")
+	})
+	t.Run("different error", func(t *testing.T) {
+		fakeT := &fakeTestingT{}
+
+		err := fmt.Errorf("the actual error")
+		Error(fakeT, err, "this error")
+		expected := `assertion failed: expected error "this error", got the actual error`
+		expectFailNowed(t, fakeT, expected)
+	})
+}
+
+func TestErrorContainsFailure(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		fakeT := &fakeTestingT{}
+
+		var err error
+		ErrorContains(fakeT, err, "this error")
+		expectFailNowed(t, fakeT, "assertion failed: expected an error, got nil")
+	})
+	t.Run("different error", func(t *testing.T) {
+		fakeT := &fakeTestingT{}
+
+		err := fmt.Errorf("the actual error")
+		ErrorContains(fakeT, err, "this error")
+		expected := `assertion failed: expected error to contain "this error", got the actual error`
+		expectFailNowed(t, fakeT, expected)
+	})
+}
+
+func TestErrorTypeFailure(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		fakeT := &fakeTestingT{}
+
+		var err error
+		ErrorType(fakeT, err, os.IsNotExist)
+		expectFailNowed(t, fakeT, "assertion failed: error is nil, not os.IsNotExist")
+	})
+	t.Run("different error", func(t *testing.T) {
+		fakeT := &fakeTestingT{}
+
+		err := fmt.Errorf("the actual error")
+		ErrorType(fakeT, err, os.IsNotExist)
+		expected := `assertion failed: error is the actual error (*errors.errorString), not os.IsNotExist`
+		expectFailNowed(t, fakeT, expected)
+	})
 }

--- a/assert/result.go
+++ b/assert/result.go
@@ -11,7 +11,7 @@ import (
 
 func runComparison(
 	t TestingT,
-	exprFilter astExprListFilter,
+	argSelector argSelector,
 	f cmp.Comparison,
 	msgAndArgs ...interface{},
 ) bool {
@@ -31,7 +31,7 @@ func runComparison(
 		if err != nil {
 			t.Log(err.Error())
 		}
-		message = typed.FailureMessage(filterPrintableExpr(exprFilter(args)))
+		message = typed.FailureMessage(filterPrintableExpr(argSelector(args)))
 	case resultBasic:
 		message = typed.FailureMessage()
 	default:
@@ -50,9 +50,7 @@ type resultBasic interface {
 	FailureMessage() string
 }
 
-type astExprListFilter func([]ast.Expr) []ast.Expr
-
-// filterPrintableExpr filters the ast.Expr slice to only include nodes that are
+// filterPrintableExpr filters the ast.Expr slice to only include Expr that are
 // easy to read when printed and contain relevant information to an assertion.
 //
 // Ident and SelectorExpr are included because they print nicely and the variable
@@ -63,24 +61,42 @@ type astExprListFilter func([]ast.Expr) []ast.Expr
 func filterPrintableExpr(args []ast.Expr) []ast.Expr {
 	result := make([]ast.Expr, len(args))
 	for i, arg := range args {
-		switch arg.(type) {
-		case *ast.Ident, *ast.SelectorExpr, *ast.IndexExpr, *ast.SliceExpr:
+		if isShortPrintableExpr(arg) {
 			result[i] = arg
-		default:
-			result[i] = nil
+			continue
 		}
+
+		if starExpr, ok := arg.(*ast.StarExpr); ok {
+			result[i] = starExpr.X
+			continue
+		}
+		result[i] = nil
 	}
 	return result
 }
 
-func filterExprExcludeFirst(args []ast.Expr) []ast.Expr {
+func isShortPrintableExpr(expr ast.Expr) bool {
+	switch expr.(type) {
+	case *ast.Ident, *ast.SelectorExpr, *ast.IndexExpr, *ast.SliceExpr:
+		return true
+	case *ast.BinaryExpr, *ast.UnaryExpr:
+		return true
+	default:
+		// CallExpr, ParenExpr, TypeAssertExpr, KeyValueExpr, StarExpr
+		return false
+	}
+}
+
+type argSelector func([]ast.Expr) []ast.Expr
+
+func argsAfterT(args []ast.Expr) []ast.Expr {
 	if len(args) < 1 {
 		return nil
 	}
 	return args[1:]
 }
 
-func filterExprArgsFromComparison(args []ast.Expr) []ast.Expr {
+func argsFromComparisonCall(args []ast.Expr) []ast.Expr {
 	if len(args) < 1 {
 		return nil
 	}


### PR DESCRIPTION
Branched from #71 

Some small internal cleanup of `assert/result.go`. Trying to improve the naming of what is now called `argSelector`.

Also refactored `filterPrintableExpr` a bit to print `StarExpr.X`.