### PR TITLE
gty-migrate-from-testify: better help text and godoc

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -8,7 +8,7 @@ comparison fails. The one difference is that Assert() will end the test executio
 immediately (using t.FailNow()) whereas Check() will fail the test (using t.Fail()),
 return the value of the comparison, then proceed with the rest of the test case.
 
-Example Usage
+Example usage
 
 The example below shows assert used with some common types.
 
@@ -49,9 +49,17 @@ The example below shows assert used with some common types.
 
 Comparisons
 
-https://godoc.org/github.com/gotestyourself/gotestyourself/assert/cmp provides
+Package assert/cmp (http://bit.do/assert-cmp) provides
 many common comparisons. Additional comparisons can be written to compare
 values in other ways. See the example Assert (CustomComparison).
+
+Automated migration from testify
+
+gty-migrate-from-testify is a binary which can update source code which uses
+testify assertions to use the assertions provided by this package.
+
+See http://bit.do/cmd-gty-migrate-from-testify.
+
 
 */
 package assert

--- a/assert/cmd/gty-migrate-from-testify/doc.go
+++ b/assert/cmd/gty-migrate-from-testify/doc.go
@@ -1,7 +1,16 @@
 /*
 
-Command gty-migration-from-testify migrates one or more packages from
+Command gty-migrate-from-testify migrates packages from
 testify/assert and testify/require to gotestyourself/assert.
+
+	$ go get github.com/gotestyourself/gotestyourself/assert/cmd/gty-migrate-from-testify
+
+Usage:
+
+	gty-migrate-from-testify [OPTIONS] PACKAGE [PACKAGE...]
+
+See --help for full usage.
+
 
 To run on all packages (including external test packages) use:
 
@@ -9,10 +18,5 @@ To run on all packages (including external test packages) use:
 		-f '{{.ImportPath}} {{if .XTestGoFiles}}{{"\n"}}{{.ImportPath}}_test{{end}}' \
 		./... | xargs gty-migrate-from-testify
 
-The cmp package can be aliases to make the assertions more readable:
-
-    gty-migrate-from-testify --import-cmp-alias=is
-
 */
-
 package main

--- a/assert/cmd/gty-migrate-from-testify/main.go
+++ b/assert/cmd/gty-migrate-from-testify/main.go
@@ -55,15 +55,22 @@ func debugf(msg string, args ...interface{}) {
 func setupFlags(name string) (*pflag.FlagSet, *options) {
 	opts := options{}
 	flags := pflag.NewFlagSet(name, pflag.ContinueOnError)
-	flags.BoolVar(&opts.dryRun, "dry-run", false, "don't write to file")
+	flags.BoolVar(&opts.dryRun, "dry-run", false,
+		"don't write changes to file")
 	flags.BoolVar(&opts.debug, "debug", false, "enable debug logging")
-	flags.StringVar(&opts.cmpImportName, "import-cmp-alias", "is",
+	flags.StringVar(&opts.cmpImportName, "cmp-pkg-import-alias", "is",
 		"import alias to use for the assert/cmp package")
 	flags.BoolVar(&opts.showLoaderErrors, "print-loader-errors", false,
 		"print errors from loading source")
 	flags.BoolVar(&opts.useAllFiles, "ignore-build-tags", false,
-		"use files regardless of +build lines, file names")
-	// TODO: set usage func to print more usage
+		"migrate all files ignoring build tags")
+	flags.Usage = func() {
+		fmt.Fprintf(os.Stderr, `Usage: %s [OPTIONS] PACKAGE [PACKAGE...]
+
+Migrate calls from testify/{assert|require} to gotestyourself/assert.
+
+%s`, name, flags.FlagUsages())
+	}
 	return flags, &opts
 }
 

--- a/assert/cmd/gty-migrate-from-testify/migrate.go
+++ b/assert/cmd/gty-migrate-from-testify/migrate.go
@@ -263,12 +263,14 @@ func convertFalse(tcall call, imports importNames) ast.Node {
 func convertEqual(tcall call, migration migration) ast.Node {
 	imports := migration.importNames
 
+	hasExtraArgs := len(tcall.extraArgs(3)) > 0
+
 	cmpEqual := convertTwoArgComparison(tcall, imports, "Equal")
 	if tcall.assert == funcNameAssert {
 		cmpEqual = newCallExprWithoutComparison(tcall, imports, "Equal")
 	}
 	cmpDeepEqual := convertTwoArgComparison(tcall, imports, "DeepEqual")
-	if tcall.assert == funcNameAssert {
+	if tcall.assert == funcNameAssert && !hasExtraArgs {
 		cmpDeepEqual = newCallExprWithoutComparison(tcall, imports, "DeepEqual")
 	}
 

--- a/assert/cmd/gty-migrate-from-testify/migrate_test.go
+++ b/assert/cmd/gty-migrate-from-testify/migrate_test.go
@@ -257,19 +257,21 @@ func TestOtherName(z *testing.T) {
 	assert.Assert(t, cmp.Equal(expected, string(actual)))
 }
 
-func TestMigrateFileWithComment(t *testing.T) {
+func TestMigrateFileWithExtraArgs(t *testing.T) {
 	source := `
 package foo
 
 import (
 	"testing"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSomething(t *testing.T) {
 	var err error
 	assert.Error(t, err, "this is a comment")
 	assert.Empty(t, nil, "more comment")
+	require.Equal(t, []string{}, []string{}, "because")
 }
 `
 	migration := newMigrationFromSource(t, source)
@@ -289,6 +291,7 @@ func TestSomething(t *testing.T) {
 	var err error
 	assert.Check(t, is.ErrorContains(err, ""), "this is a comment")
 	assert.Check(t, is.Len(nil, 0), "more comment")
+	assert.Assert(t, is.DeepEqual([]string{}, []string{}), "because")
 }
 `
 	actual, err := formatFile(migration)


### PR DESCRIPTION
Also fix a bug with DeepEqual and extra args.