### PR TITLE
testsum: deprecate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ patterns.
   test asynchronous code by polling until a desired state is reached
 * [skip](http://godoc.org/github.com/gotestyourself/gotestyourself/skip) -
   skip tests based on conditions
-* [testsum](http://godoc.org/github.com/gotestyourself/gotestyourself/testsum) -
-  a program to summarize `go test` output and test failures
 
 ## Related
 

--- a/testsum/scan.go
+++ b/testsum/scan.go
@@ -1,4 +1,8 @@
-/*Package testsum provides functions for parsing `go test -v` output and returning
+/*Package testsum is DEPRECATED.
+
+This functionality is now available from `go tool test2json` in the stdlib.
+
+Package testsum provides functions for parsing `go test -v` output and returning
 a summary of the test run.
 
 Build the executable:


### PR DESCRIPTION
This functionality is now available from `go tool test2json` in the stdlib as of go1.10.

I have a branch which uses that output to create a better version of `testsum/cmd`, but I'm thinking it should be a separate project in the `gotestyourself` org, since it's primarily a binary not a library.